### PR TITLE
fix: asset url in example env

### DIFF
--- a/example.dev.env
+++ b/example.dev.env
@@ -18,7 +18,7 @@ bCMS__DB_DATABASE=adamrms
 bCMS__DB_USERNAME=root
 bCMS__DB_PASSWORD=root
 
-bCMS__ASSETS_URL=https://assets.adam-rms.com/file/AdamRMS-assets
+bCMS__ASSETS_URL=https://cdn.adam-rms.com
 
 bCMS__JWT=RandomString
 


### PR DESCRIPTION
I believe that the asset URL got changed at a version which caused issues in fetching the stylesheets and made for a horrible experience. 

I have changed this to be updated with the `dash.adam-rms.com` site however that may be incorrect
