### PR TITLE
Use HTML editor rather than Markdown for project comments

### DIFF
--- a/html/admin/api/projects/newQuickComment.php
+++ b/html/admin/api/projects/newQuickComment.php
@@ -9,6 +9,6 @@ $DBLIB->where("projects.projects_id", $_POST['projects_id']);
 $project = $DBLIB->getone("projects", ["projects.projects_id"]);
 if (!$project) die("404");
 
-$bCMS->auditLog("QUICKCOMMENT", "projects", $_POST['text'], $AUTH->data['users_userid'],null, $_POST['projects_id']);
+$bCMS->auditLog("QUICKCOMMENT", "projects", $bCMS->cleanString($_POST['text']), $AUTH->data['users_userid'],null, $_POST['projects_id']);
 
 finish(true, null, ["projects_id" => $project]);

--- a/html/admin/project/project_index.twig
+++ b/html/admin/project/project_index.twig
@@ -3,12 +3,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.5/daterangepicker.min.css" integrity="sha256-VVbO1uqtov1mU6f9qu/q+MfDmrqTfoba0rAE07szS20=" crossorigin="anonymous" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.5/daterangepicker.min.js" integrity="sha256-zI6VVO07NPmVW11q3RQE42YbRmJIkkunrcQ9LEYxJsQ=" crossorigin="anonymous"></script>
-    <!--Tui Markdown Editor-->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tui-editor/1.4.10/tui-editor.min.css" integrity="sha512-+nHZBZFGJmRq9QyYL/lROrtz2+FGBcZ7LqPFcY1YrjwbseBOFMeBRSBj62odrEb4PSusWeY98ZjFoMMdptTckQ==" crossorigin="anonymous" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tui-editor/1.4.10/tui-editor-contents.min.css" integrity="sha512-Kkjhkgw5Mb8Gy2adx3NQMYE76lFgoof9HZIR04/hFBnJwCrYEQ/FzDgmXfMaF42lND3X0tltPLumRV3slqn+9Q==" crossorigin="anonymous" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.59.2/codemirror.min.css" integrity="sha512-MWdvo/Qqcf4pY1ecQUB1uBn0qLp19U/qJ1Rpp2BDZeuBA7YsFEwkvqR/+aG4BroPiAYDunKJ6X8R/Pmdt3p7oA==" crossorigin="anonymous" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/github.min.css" integrity="sha512-FwY1WVsm4UQgrOXt6kaQ53w83cOHa8fSvjFn/BvVOCYVPmkSR39k/xnU+8hht3zW6JL1TBd4C/aVQIAV58Cg6A==" crossorigin="anonymous" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tui-editor/1.4.10/tui-editor-Editor-full.min.js" integrity="sha512-8Orlh5xln1WzQ/AoRmsYlhsb5WORMTopCb4wyIhZRQVSCgB0gAPDkHKRNJdxLI5E5yt3nkLQX/TyUKz82FzOJw==" crossorigin="anonymous"></script>
     <style>
         .color-palette {
             height: 35px;
@@ -50,6 +44,11 @@
             font-size: 12px;
             display: block;
             z-index: 7;
+        }
+
+        /* Remove bottom margin from comment cards */
+        .timeline-body > p {
+            margin-bottom: 0;
         }
     </style>
 
@@ -333,15 +332,7 @@
                                                                     <span class="time"><i class="fas fa-clock"></i> {{ event.auditLog_timestamp|date("h:i:sa") }}</span>
                                                                     <h3 class="timeline-header"><a href="mailto:{{ event.users_email }}">{{ event.users_name1 ~ " " ~ event.users_name2}} </a> commented
                                                                     </h3>
-                                                                    <div class="timeline-body" id="event-{{ event.auditLog_id }}"><i>Loading Comment</i></div>
-                                                                    <script>
-                                                                        new tui.Editor.factory({
-                                                                            el: document.querySelector('#event-{{ event.auditLog_id }}'),
-                                                                            viewer: true,
-                                                                            height: 'auto',
-                                                                            initialValue: "{{ event.auditLog_actionData|replace({"\n":'  \\n', "\r":''}) }}",
-                                                                        })
-                                                                    </script>
+                                                                    <div class="timeline-body">{{ event.auditLog_actionData|raw }}</div>
                                                                 </div>
                                                             </div>
                                                         {% endif %}
@@ -945,15 +936,7 @@
                                                                 {% endif %}
                                                             </h3>
                                                             {% if event.auditLog_actionType == "QUICKCOMMENT" %}
-                                                                <div class="timeline-body" id="comment-{{ event.auditLog_id }}"><i>Loading Comment</i></div>
-                                                                <script>
-                                                                    new tui.Editor.factory({
-                                                                        el: document.querySelector('#comment-{{ event.auditLog_id }}'),
-                                                                        viewer: true,
-                                                                        height: 'auto',
-                                                                        initialValue: "{{ event.auditLog_actionData|replace({"\n":'  \\n', "\r":''}) }}",
-                                                                    })
-                                                                </script>
+                                                                <div class="timeline-body">{{ event.auditLog_actionData|raw }}</div>
                                                             {% elseif event.auditLog_actionType in ['INSERT', 'ARCHIVE','UNARCHIVE','CHANGE-MANAGER','UPDATE-NAME','UPDATE-STATUS','CHANGE-CLIENT'] %}
                                                                 {# Blank #}
                                                             {% else %}
@@ -1357,7 +1340,7 @@
                             label: "Save",
                             className: "btn btn-info",
                             callback: function () {
-                                let content = editor.getMarkdown();
+                                let content = $('#editor').summernote('code');
                                 if (content){
                                     ajaxcall("projects/newQuickComment.php", {
                                         "text": content,
@@ -1374,37 +1357,29 @@
                         }
                     }
                 });
-                let editor = new tui.Editor({
-                    el: document.querySelector('#editor'),
-                    height: 'auto',
-                    initialEditType: 'wysiwyg',
-                    usageStatistics: false,
-                    initialValue:'',
-                    language: "en_GB",
-                    placeholder: "Client has requested a Drum Revolve be installed in the venue before get in.",
-                    hideModeSwitch: false,
-                    toolbarItems: [
-                        'heading',
-                        'bold',
-                        'italic',
-                        'strike',
-                        'divider',
-                        //'hr',
-                        //'quote',
-                        //'divider',
-                        'ul',
-                        'ol',
-                        'task',
-                        'indent',
-                        'outdent',
-                        'divider',
-                        // 'table',
-                        // 'image',
-                        'link',
-                        'divider',
-                        //'code',
-                        //'codeblock'
+
+                $('#editor').summernote({
+                    minHeight: 300,             // set minimum height of editor
+                    maxHeight: null,             // set maximum height of editor
+                    focus: true,
+                    disableDragAndDrop: true, //We're using fineuploader for that
+                    toolbar: [
+                        ['oops', ['undo', 'redo']],
+                        ['font', ['style', 'bold', 'italic', 'underline', 'strikethrough', 'superscript', 'subscript', 'clear']],
+                        ['para', ['ul', 'ol', 'paragraph']],
+                        ['insert', ['link','hr']],
+                        ['view', ['codeview']]
                     ],
+                    popover: {
+                        image: [
+                            ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],
+                            ['float', ['floatLeft', 'floatRight', 'floatNone']],
+                            ['remove', ['removeMedia']]
+                        ],
+                        link: [
+                            ['link', ['unlink']]
+                        ],
+                    }
                 });
             });
             {% if 22|instancePermissions %}


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

Converts comments popup to summernote, instead of TUI markdown editor. 


### References

Closes #222 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`