### PR TITLE
fix: update the asset discount text

### DIFF
--- a/html/admin/project/project_assets.twig
+++ b/html/admin/project/project_assets.twig
@@ -228,7 +228,7 @@
             if (selected.length > 0) {
                 bootbox.prompt({
                     title: "Set Discount",
-                    message: "Discount the selected assets by a percentage.<br><br>E.g. Inputing 20 would multiply the price by 0.8",
+                    message: "Discount the selected assets by a percentage.<br><br>E.g. Inputing 20 would multiply the price by 0.8<br>This will override any existing discounts set in this project for the assets selected.",
                     inputType: 'number',
                     min: 0,
                     max: 100,

--- a/html/admin/project/project_assets.twig
+++ b/html/admin/project/project_assets.twig
@@ -228,7 +228,7 @@
             if (selected.length > 0) {
                 bootbox.prompt({
                     title: "Set Discount",
-                    message: "Discounts the selected assets by a percentage.<br><br>E.g. Inputting 20 would multiply the price by 0.8<br>This will override any existing discounts set in this project for the assets selected.",
+                    message: "Discounts the selected assets by a percentage.<br /><br />E.g. Inputting 20 would multiply the price by 0.8<br />This will override any existing discounts set in this project for the assets selected.",
                     inputType: 'number',
                     min: 0,
                     max: 100,

--- a/html/admin/project/project_assets.twig
+++ b/html/admin/project/project_assets.twig
@@ -228,7 +228,7 @@
             if (selected.length > 0) {
                 bootbox.prompt({
                     title: "Set Discount",
-                    message: "Discount the selected assets by a percentage.<br><br>E.g. Inputing 20 would multiply the price by 0.8<br>This will override any existing discounts set in this project for the assets selected.",
+                    message: "Discount the selected assets by a percentage.<br><br>E.g. Inputting 20 would multiply the price by 0.8<br>This will override any existing discounts set in this project for the assets selected.",
                     inputType: 'number',
                     min: 0,
                     max: 100,

--- a/html/admin/project/project_assets.twig
+++ b/html/admin/project/project_assets.twig
@@ -228,7 +228,7 @@
             if (selected.length > 0) {
                 bootbox.prompt({
                     title: "Set Discount",
-                    message: "Discount the selected assets by a percentage.<br><br>E.g. Inputting 20 would multiply the price by 0.8<br>This will override any existing discounts set in this project for the assets selected.",
+                    message: "Discounts the selected assets by a percentage.<br><br>E.g. Inputting 20 would multiply the price by 0.8<br>This will override any existing discounts set in this project for the assets selected.",
                     inputType: 'number',
                     min: 0,
                     max: 100,

--- a/html/admin/project/project_assets.twig
+++ b/html/admin/project/project_assets.twig
@@ -228,7 +228,7 @@
             if (selected.length > 0) {
                 bootbox.prompt({
                     title: "Set Discount",
-                    message: "Example: a discount of 20% would multiply the hire cost by 0.8<br/><br/>This will override any existing discounts set in this project for the assets selected",
+                    message: "Discount the selected assets by a percentage.<br><br>E.g. Inputing 20 would multiply the price by 0.8",
                     inputType: 'number',
                     min: 0,
                     max: 100,


### PR DESCRIPTION
I personally found the discount text quite confusing. "Example: a discount of 20% would multiply the hire cost by 0.8". Hopefully this clarifies for future users.
