### PR TITLE
Fix server crashes from running out of memory

### DIFF
--- a/html/admin/api/s3files/projectInvoice.php
+++ b/html/admin/api/s3files/projectInvoice.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/../apiHeadSecure.php';
 ini_set('max_execution_time', 300); //seconds
-ini_set('memory_limit','2048M');
+ini_set('memory_limit','256M');
 
 require_once __DIR__ . '/../projects/data.php'; //Where most of the data comes from
 

--- a/html/admin/project/index.php
+++ b/html/admin/project/index.php
@@ -1,5 +1,5 @@
 <?php
-ini_set('memory_limit','2048M');
+ini_set('memory_limit','256M');
 require_once __DIR__ . '/../common/headSecure.php';
 if (!$AUTH->instancePermissionCheck(20) or !isset($_GET['id'])) die($TWIG->render('404.twig', $PAGEDATA));
 

--- a/php.ini
+++ b/php.ini
@@ -427,7 +427,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume
 ; http://php.net/memory-limit
-memory_limit = 2G
+memory_limit = 256M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
We're having this issue where the server crashes horribly if you generate a PDF invoice for a big project.

