### PR TITLE
346 Add Role groups to training modules

### DIFF
--- a/db/migrations/20220612180311_training_user_roles.php
+++ b/db/migrations/20220612180311_training_user_roles.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class TrainingUserRoles extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $this->table('modules')
+        ->addColumn('modules_visibleToGroups', 'string',[
+            'null' => true,
+            'default' => null,
+            'after' => "modules_learningObjectives"
+        ])
+        ->save();
+    }
+}

--- a/html/admin/api/modules/edit.php
+++ b/html/admin/api/modules/edit.php
@@ -4,13 +4,19 @@ require_once __DIR__ . '/../apiHeadSecure.php';
 if (!$AUTH->instancePermissionCheck(116)) die("404");
 
 $array = [];
+$array['modules_visibleToGroups'] = [];
 foreach ($_POST['formData'] as $item) {
     if ($item['value'] == '') $item['value'] = null;
-    $array[$item['name']] = $item['value'];
+
+    if ($item['name'] == 'modules_visibleToGroups') array_push($array['modules_visibleToGroups'],$item['value']);
+    else $array[$item['name']] = $item['value'];
 }
 if (strlen($array['modules_id']) <1) finish(false, ["code" => "PARAM-ERROR", "message"=> "No data for action"]);
 if ($array['modules_show']) $array['modules_show'] = 1;
 else $array['modules_show'] = 0;
+
+if ($array['modules_visibleToGroups'] == []) $array['modules_visibleToGroups'] = null;
+else $array['modules_visibleToGroups'] = implode(",",$array['modules_visibleToGroups']);
 
 $DBLIB->where("modules.modules_deleted", 0);
 $DBLIB->where("modules.instances_id", $AUTH->data['instance']['instances_id']);

--- a/html/admin/training/index.php
+++ b/html/admin/training/index.php
@@ -14,9 +14,9 @@ if ($AUTH->instancePermissionCheck(114) and isset($_GET['drafts'])) {
     $DBLIB->where("modules.modules_show", 0);
 }
 else $DBLIB->where("modules.modules_show", 1);
-if ($AUTH->data['instance']["instancePositions_id"] && (!$AUTH->instancePermissionCheck(116))) {
+if ($AUTH->data['instance']["instancePositions_id"] && !$AUTH->instancePermissionCheck(116) && !$AUTH->instancePermissionCheck(117)) {
     //If the user doesn't have a position - they're bstudios staff
-    //If user has permission to edit modules, let them see all of them, otherwise they'll be impossible to edit
+    //If user has permission to edit modules or view users , let them see all of them, otherwise they'll be impossible to edit
     $DBLIB->where("(modules.modules_visibleToGroups IS NULL OR (FIND_IN_SET(" . $AUTH->data['instance']["instancePositions_id"] . ", modules.modules_visibleToGroups) > 0))"); 
 }
 $DBLIB->where("modules.instances_id", $AUTH->data['instance']['instances_id']);
@@ -71,6 +71,11 @@ foreach ($modules as $module) {
         $module['totalTime'] += $step["modulesSteps_completionTime"];
     }
 
+    $module['canComplete'] = true;
+    //for users with edit permission, check if they're actually allowed to complete this module, or just edit it
+    if ($AUTH->instancePermissionCheck(116) && (!in_array($AUTH->data['instance']["instancePositions_id"], explode(',',$module['modules_visibleToGroups'])))){
+        $module['canComplete'] = false;
+    }
 
     $PAGEDATA['modules'][] = $module;
 }

--- a/html/admin/training/index.php
+++ b/html/admin/training/index.php
@@ -14,6 +14,11 @@ if ($AUTH->instancePermissionCheck(114) and isset($_GET['drafts'])) {
     $DBLIB->where("modules.modules_show", 0);
 }
 else $DBLIB->where("modules.modules_show", 1);
+if ($AUTH->data['instance']["instancePositions_id"] && (!$AUTH->instancePermissionCheck(116))) {
+    //If the user doesn't have a position - they're bstudios staff
+    //If user has permission to edit modules, let them see all of them, otherwise they'll be impossible to edit
+    $DBLIB->where("(modules.modules_visibleToGroups IS NULL OR (FIND_IN_SET(" . $AUTH->data['instance']["instancePositions_id"] . ", modules.modules_visibleToGroups) > 0))"); 
+}
 $DBLIB->where("modules.instances_id", $AUTH->data['instance']['instances_id']);
 $DBLIB->orderBy("modules.modules_name","ASC");
 $modules = $DBLIB->arraybuilder()->paginate('modules', $page, ["modules.*"]);
@@ -69,6 +74,11 @@ foreach ($modules as $module) {
 
     $PAGEDATA['modules'][] = $module;
 }
+
+$DBLIB->orderBy("instancePositions_rank", "ASC");
+$DBLIB->where("instances_id", $AUTH->data['instance']['instances_id']);
+$DBLIB->where("instancePositions_deleted",0);
+$PAGEDATA['positions'] = $DBLIB->get("instancePositions");
 
 
 echo $TWIG->render('training/training_modules.twig', $PAGEDATA);

--- a/html/admin/training/module.php
+++ b/html/admin/training/module.php
@@ -8,7 +8,7 @@ $DBLIB->where("modules.modules_deleted", 0);
 if (!$AUTH->instancePermissionCheck(114)) $DBLIB->where("modules.modules_show", 1);
 // Check if module has group visibility permissions
 // if the user can edit modules and is trying to edit this module (ie. viewing steps or users), ignore group visibility permissions
-if ($AUTH->data['instance']["instancePositions_id"] && !(($AUTH->instancePermissionCheck(116) && isset($_GET['steps'])) || ($AUTH->instancePermissionCheck(117) &&isset($_GET['users'])) )) {
+if ($AUTH->data['instance']["instancePositions_id"] && !(($AUTH->instancePermissionCheck(116) && isset($_GET['steps'])) || ($AUTH->instancePermissionCheck(117) && isset($_GET['users'])) )) {
     $DBLIB->where("(modules.modules_visibleToGroups IS NULL OR (FIND_IN_SET(" . $AUTH->data['instance']["instancePositions_id"] . ", modules.modules_visibleToGroups) > 0))");
 } 
 // Check if module has steps to complete - ie. not a physical only module (type 3)

--- a/html/admin/training/module.php
+++ b/html/admin/training/module.php
@@ -5,6 +5,7 @@ if (!$AUTH->instancePermissionCheck(113)) die($TWIG->render('404.twig', $PAGEDAT
 
 $DBLIB->where("modules.modules_deleted", 0);
 if (!$AUTH->instancePermissionCheck(114)) $DBLIB->where("modules.modules_show", 1);
+if ($AUTH->data['instance']["instancePositions_id"]) $DBLIB->where("(modules.modules_visibleToGroups IS NULL OR (FIND_IN_SET(" . $AUTH->data['instance']["instancePositions_id"] . ", modules.modules_visibleToGroups) > 0))");
 $DBLIB->where("modules.modules_id", $_GET['id']);
 $DBLIB->where("modules.instances_id", $AUTH->data['instance']['instances_id']);
 $PAGEDATA['module'] = $DBLIB->getOne('modules', ["modules.*"]);

--- a/html/admin/training/module.php
+++ b/html/admin/training/module.php
@@ -4,8 +4,15 @@ require_once __DIR__ . '/../common/headSecure.php';
 if (!$AUTH->instancePermissionCheck(113)) die($TWIG->render('404.twig', $PAGEDATA));
 
 $DBLIB->where("modules.modules_deleted", 0);
+// If user does not have draft edit permissions, only show live modules
 if (!$AUTH->instancePermissionCheck(114)) $DBLIB->where("modules.modules_show", 1);
-if ($AUTH->data['instance']["instancePositions_id"]) $DBLIB->where("(modules.modules_visibleToGroups IS NULL OR (FIND_IN_SET(" . $AUTH->data['instance']["instancePositions_id"] . ", modules.modules_visibleToGroups) > 0))");
+// Check if module has group visibility permissions
+// if the user can edit modules and is trying to edit this module (ie. viewing steps or users), ignore group visibility permissions
+if ($AUTH->data['instance']["instancePositions_id"] && !(($AUTH->instancePermissionCheck(116) && isset($_GET['steps'])) || ($AUTH->instancePermissionCheck(117) &&isset($_GET['users'])) )) {
+    $DBLIB->where("(modules.modules_visibleToGroups IS NULL OR (FIND_IN_SET(" . $AUTH->data['instance']["instancePositions_id"] . ", modules.modules_visibleToGroups) > 0))");
+} 
+// Check if module has steps to complete - ie. not a physical only module (type 3)
+$DBLIB->where("modules.modules_type != 3");
 $DBLIB->where("modules.modules_id", $_GET['id']);
 $DBLIB->where("modules.instances_id", $AUTH->data['instance']['instances_id']);
 $PAGEDATA['module'] = $DBLIB->getOne('modules', ["modules.*"]);

--- a/html/admin/training/training_modules.twig
+++ b/html/admin/training/training_modules.twig
@@ -87,7 +87,7 @@
                             <div class="btn-group">
                                 {% if 116|instancePermissions %}
                                     <button data-toggle="modal" data-target="#editModuleModal{{ module.modules_id }}" class="btn btn-sm btn-default" title="Edit"><i class="fas fa-edit"></i></button>
-                                    {% if module.modules_tye != 3 %}
+                                    {% if module.modules_type != 3 %}
                                     <a href="{{ CONFIG.ROOTURL }}/training/module.php?id={{ module.modules_id }}&steps" class="btn btn-sm btn-default" title="Edit Module Steps">
                                         <i class="fas fa-chalkboard-teacher"></i>
                                     </a>
@@ -98,7 +98,7 @@
                                         <i class="fas fa-user-graduate"></i>
                                     </a>
                                 {% endif %}
-                                {% if module.modules_type != 3 %}
+                                {% if module.modules_type != 3 and module.canComplete %}
                                 <a href="{{ CONFIG.ROOTURL }}/training/module.php?id={{ module.modules_id }}" class="btn btn-sm btn-default" title="Work on Module">
                                     {% if module.completed %}
                                         <i class="fas fa-list-ol"></i>

--- a/html/admin/training/training_modules.twig
+++ b/html/admin/training/training_modules.twig
@@ -156,12 +156,6 @@
                             </div>
                             <div class="input-group" style="margin-bottom: 5px;">
                                 <div class="input-group-prepend">
-                                    <span class="input-group-text">Publish in the module catalogue to be completed by users</span>
-                                </div>
-                                <input required type="checkbox" class="form-control" name="modules_show" {{ module.modules_show == 1 ? 'checked' : ''}}>
-                            </div>
-                            <div class="input-group" style="margin-bottom: 5px;">
-                                <div class="input-group-prepend">
                                     <span class="input-group-text">Type</span>
                                 </div>
                                 <select name="modules_type" class="form-control" value="{{ module.modules_type }}">
@@ -170,6 +164,22 @@
                                     <option value="3" {{ module.modules_type == 3 ? 'selected' }}>Physical: Users cannot complete the module themselves - they are certified by an administrator</option>
                                 </select>
                             </div>
+                            <hr/>
+                            <div class="input-group" style="margin-bottom: 5px;">
+                                <div class="input-group-prepend">
+                                    <span class="input-group-text">Publish in the module catalogue to be completed by users</span>
+                                </div>
+                                <input required type="checkbox" class="form-control" name="modules_show" {{ module.modules_show == 1 ? 'checked' : ''}}>
+                            </div>
+                            <div class="form-group">
+                                <label>Limit visibility to:</label>
+                                <select multiple class="form-control select2 select2bs4" name="modules_visibleToGroups">
+                                    {% for position in positions %}
+                                        <option value="{{ position.instancePositions_id }}" {% if position.instancePositions_id in module.modules_visibleToGroups|split(',') %}selected{% endif %}>{{ position.instancePositions_displayName }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <hr/>
 
                             <h4>Thumbnail</h4>
                             <input type="hidden" name="modules_thumbnail" value="{{ module.modules_thumbnail }}" id="moduleThumbnail{{ module.modules_id }}" />
@@ -191,6 +201,10 @@
     {% endif %}
     <script>
         $(document).ready(function () {
+            $('.modal .select2').select2({
+                theme: "bootstrap4",
+                width: '100%'
+            });
             {% if 116|instancePermissions %}
             $(".saveEditForm").click(function () {
                 if ($(this).data("id")) {

--- a/html/admin/training/training_modules.twig
+++ b/html/admin/training/training_modules.twig
@@ -44,6 +44,11 @@
                                 <span class="badge badge-danger">NOT STARTED</span>
                             {% endif %}
                         {% endif %}
+                        {% if module.visibleToGroupsString %}
+                            <span class="badge badge-info" style="text-transform: uppercase;">
+                                Visible only to {{ module.visibleToGroupsString }}
+                            </span>
+                        {% endif %}
                         <br/>
                         {% if module.modules_type != 3 %}
                             <a href="{{ CONFIG.ROOTURL }}/training/module.php?id={{ module.modules_id }}">{{ module.modules_name }}</a>
@@ -67,6 +72,8 @@
                             <br/>
                         {% endif %}
                         <p class="text-muted">{{ module.modules_description|nl2br }}</p>
+                        <p class="text-muted">{{ module.modules_learningObjectives|nl2br  }}</p>
+                        <hr />
                         <ul class="ml-4 mb-0 fa-ul text-muted">
                             {% if module.totalTime > 0 %}<li><i class="far fa-clock" title="Estimated completion time"></i> ~{{ module.totalTime }}m</li>{% endif %}
                             {% if module.modules_type != 1 %}
@@ -79,8 +86,16 @@
                             {% if module.modules_type != 3 and module.dates.start %}
                             <li><i class="far fa-calendar-alt"></i> {{ module.dates.start|date("d M Y") }}{{ (module.dates.start|date("d M Y") != module.dates.updated|date("d M Y") ? " - " ~ module.dates.updated|date("d M Y") : "") }}</li>
                             {% endif %}
+                            <li>
+                                {% if module.modules_type == 1 %}
+                                    You can complete this module online
+                                {% elseif module.modules_type == 2 %}
+                                    You can complete this module online, and then need to be certified by an administrator
+                                {% elseif module.modules_type == 3 %}
+                                    You can't complete this module online
+                                {% endif %}
+                            </li>
                         </ul>
-                        <p class="text-muted"><br/>{{ module.modules_learningObjectives|nl2br  }}</p>
                     </div>
                     <div class="card-footer">
                         <div class="text-right">
@@ -201,7 +216,7 @@
     {% endif %}
     <script>
         $(document).ready(function () {
-            $('.modal .select2').select2({
+            $('.select2').select2({
                 theme: "bootstrap4",
                 width: '100%'
             });


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

Adds Limit visibility to Training modules
![Training Popup changes](https://user-images.githubusercontent.com/54247748/173248174-5774f315-7729-42b6-9eb0-32d018abbff0.png)



### References

Closes #346 

Documented in adam-rms/website#24

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`