### PR TITLE
Add option to follow parent project status

### DIFF
--- a/db/migrations/20220723094820_sub_project_status_tracking.php
+++ b/db/migrations/20220723094820_sub_project_status_tracking.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class SubProjectStatusTracking extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $this->table('projects')
+        ->addColumn('projects_status_follow_parent', 'boolean',[
+            'null' => true,
+            'default' => null,
+            'after' => "projects_parent_project_id"
+        ])
+        ->save();
+    }
+}

--- a/html/admin/api/projects/changeStatus.php
+++ b/html/admin/api/projects/changeStatus.php
@@ -4,47 +4,64 @@ require_once __DIR__ . '/../apiHeadSecure.php';
 
 if (!$AUTH->instancePermissionCheck(29) or !isset($_POST['projects_id'])) die("404");
 
-$DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
-$DBLIB->where("projects.projects_deleted", 0);
-$DBLIB->where("projects.projects_id", $_POST['projects_id']);
-$project = $DBLIB->getone("projects", ["projects_id", "projects_status","projects_dates_deliver_start","projects_dates_deliver_end"]);
-if (!$project) finish(false);
+function changeStatus($DBLIB, $AUTH, $bCMS, $projectID) {
+    $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
+    $DBLIB->where("projects.projects_deleted", 0);
+    $DBLIB->where("projects.projects_id", $projectID);
+    $project = $DBLIB->getone("projects", ["projects_id", "projects_status","projects_dates_deliver_start","projects_dates_deliver_end"]);
+    if (!$project) finish(false);
 
-$thisStatus = $GLOBALS['STATUSES'][$project['projects_status']];
-$newStatus = $GLOBALS['STATUSES'][$_POST['projects_status']];
-if (!$newStatus) finish(false);
+    $thisStatus = $GLOBALS['STATUSES'][$project['projects_status']];
+    $newStatus = $GLOBALS['STATUSES'][$_POST['projects_status']];
+    if (!$newStatus) finish(false);
 
-if ($thisStatus["assetsAvailable"] && $newStatus["assetsAvailable"] != true) {
-    //We're taking the project from a state where its assets had been released to a state where its assets are now locked down
-    $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
-    $DBLIB->where("assetsAssignments.projects_id", $project['projects_id']);
-    $assets = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assets_id", "assetsAssignments.assetsAssignments_id"]);
-    if ($assets) {
-        $unavailableAssets = [];
-        foreach ($assets as $asset) {
-            $DBLIB->where("assetsAssignments.assets_id", $asset['assets_id']);
-            $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
-            $DBLIB->where("projects.projects_status NOT IN (" . implode(",", $GLOBALS['STATUSES-AVAILABLE']) . ")");
-            $DBLIB->where("projects.projects_deleted", 0);
-            $DBLIB->join("projects", "assetsAssignments.projects_id=projects.projects_id", "LEFT");
-            $DBLIB->join("assets","assetsAssignments.assets_id=assets.assets_id", "LEFT");
-            $DBLIB->join("assetTypes", "assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT");
-            $DBLIB->where("((projects_dates_deliver_start >= '" . $project["projects_dates_deliver_start"]  . "' AND projects_dates_deliver_start <= '" . $project["projects_dates_deliver_end"] . "') OR (projects_dates_deliver_end >= '" . $project["projects_dates_deliver_start"] . "' AND projects_dates_deliver_end <= '" . $project["projects_dates_deliver_end"] . "') OR (projects_dates_deliver_end >= '" . $project["projects_dates_deliver_end"] . "' AND projects_dates_deliver_start <= '" . $project["projects_dates_deliver_start"] . "'))");
-            $assignment = $DBLIB->getone("assetsAssignments", null, ["assetsAssignments.assetsAssignments_id", "assetsAssignments.assets_id","assetsAssignments.projects_id", "assetTypes.assetTypes_name", "projects.projects_name", "assets.assets_tag"]);
-            if ($assignment) {
-                $assignment['old_assetsAssignments_id'] = $asset['assetsAssignments_id'];
-                $unavailableAssets[] = $assignment;
+    if ($thisStatus["assetsAvailable"] && $newStatus["assetsAvailable"] != true) {
+        //We're taking the project from a state where its assets had been released to a state where its assets are now locked down
+        $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
+        $DBLIB->where("assetsAssignments.projects_id", $project['projects_id']);
+        $assets = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assets_id", "assetsAssignments.assetsAssignments_id"]);
+        if ($assets) {
+            $unavailableAssets = [];
+            foreach ($assets as $asset) {
+                $DBLIB->where("assetsAssignments.assets_id", $asset['assets_id']);
+                $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
+                $DBLIB->where("projects.projects_status NOT IN (" . implode(",", $GLOBALS['STATUSES-AVAILABLE']) . ")");
+                $DBLIB->where("projects.projects_deleted", 0);
+                $DBLIB->join("projects", "assetsAssignments.projects_id=projects.projects_id", "LEFT");
+                $DBLIB->join("assets","assetsAssignments.assets_id=assets.assets_id", "LEFT");
+                $DBLIB->join("assetTypes", "assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT");
+                $DBLIB->where("((projects_dates_deliver_start >= '" . $project["projects_dates_deliver_start"]  . "' AND projects_dates_deliver_start <= '" . $project["projects_dates_deliver_end"] . "') OR (projects_dates_deliver_end >= '" . $project["projects_dates_deliver_start"] . "' AND projects_dates_deliver_end <= '" . $project["projects_dates_deliver_end"] . "') OR (projects_dates_deliver_end >= '" . $project["projects_dates_deliver_end"] . "' AND projects_dates_deliver_start <= '" . $project["projects_dates_deliver_start"] . "'))");
+                $assignment = $DBLIB->getone("assetsAssignments", null, ["assetsAssignments.assetsAssignments_id", "assetsAssignments.assets_id","assetsAssignments.projects_id", "assetTypes.assetTypes_name", "projects.projects_name", "assets.assets_tag"]);
+                if ($assignment) {
+                    $assignment['old_assetsAssignments_id'] = $asset['assetsAssignments_id'];
+                    $unavailableAssets[] = $assignment;
+                }
+            }
+            if (count($unavailableAssets) > 0) {
+                finish(true, null, ["changed" => false, "assets" => $unavailableAssets]);
             }
         }
-        if (count($unavailableAssets) > 0) {
-            finish(true, null, ["changed" => false, "assets" => $unavailableAssets]);
-        }
+
     }
 
+    $DBLIB->where("projects.projects_id", $project['projects_id']);
+    $projectupdate =  $DBLIB->update("projects", ["projects.projects_status" => $_POST['projects_status']]);
+    if (!$projectupdate) finish(false);
+    $bCMS->auditLog("UPDATE-STATUS", "projects", "Set the status to ". $GLOBALS['STATUSES'][$_POST['projects_status']]['name'], $AUTH->data['users_userid'],null, $projectID);
 }
 
-$DBLIB->where("projects.projects_id", $project['projects_id']);
-$projectupdate =  $DBLIB->update("projects", ["projects.projects_status" => $_POST['projects_status']]);
-if (!$projectupdate) finish(false);
-$bCMS->auditLog("UPDATE-STATUS", "projects", "Set the status to ". $GLOBALS['STATUSES'][$_POST['projects_status']]['name'], $AUTH->data['users_userid'],null, $_POST['projects_id']);
+//update this project
+changeStatus($DBLIB, $AUTH, $bCMS, $_POST['projects_id']);
+
+//Update any sub-projects that follow their parent project's status
+$DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
+$DBLIB->where("projects.projects_deleted", 0);
+$DBLIB->where("projects.projects_parent_project_id", $_POST['projects_id']);
+$DBLIB->where("projects.projects_status_follow_parent", 1);
+$subProjects = $DBLIB->get("projects", null, ["projects_id"]);
+
+foreach ($subProjects as $key => $value) {
+    changeStatus($DBLIB, $AUTH, $bCMS, $value['projects_id']);
+}
+
 finish(true, null, ["changed" => true]);

--- a/html/admin/api/projects/followParentStatus.php
+++ b/html/admin/api/projects/followParentStatus.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * API
+ * \projects\followParentStatus.php
+ * Set whether a subproject follows the status of its parent project
+ *
+ * Arguments:
+ *  - projects_id: a project
+ *  - follow: boolean to follow or not
+ */
+
+require_once __DIR__ . '/../apiHeadSecure.php';
+
+if (!$AUTH->instancePermissionCheck(21) or !isset($_POST['projects_id']) or !isset($_POST['follow'])) finish(false);
+
+
+
+if ($_POST['follow'] === 'true') {
+    // Get project
+    $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
+    $DBLIB->where("projects.projects_deleted", 0);
+    $DBLIB->where("projects.projects_id", $_POST['projects_id']);
+    $DBLIB->where("projects.projects_parent_project_id", NULL, 'IS NOT');
+    $project = $DBLIB->getone("projects", ["projects_parent_project_id"]);
+    if (!$project) finish(false);
+
+    //get parent project status
+    $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
+    $DBLIB->where("projects.projects_deleted", 0);
+    $DBLIB->where("projects.projects_id", $project['projects_parent_project_id']);
+    $parentProject = $DBLIB->getone("projects", ["projects_status"]);
+    if (!$parentProject) finish(false);
+
+    //set subproject status to parent project status
+    $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
+    $DBLIB->where("projects.projects_deleted", 0);
+    $DBLIB->where("projects.projects_id", $_POST['projects_id']);
+    $DBLIB->update("projects", ["projects_status" => $parentProject['projects_status'], "projects_status_follow_parent" => 1]);
+    
+    finish(true, null, ["changed" => true]);
+} else {
+    //stop following parent status
+    $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
+    $DBLIB->where("projects.projects_deleted", 0);
+    $DBLIB->where("projects.projects_id", $_POST['projects_id']);
+    $DBLIB->update("projects", ["projects_status_follow_parent" => 0]);
+
+    finish(true, null, ["changed" => true]);
+}

--- a/html/admin/project/project_index.twig
+++ b/html/admin/project/project_index.twig
@@ -2120,7 +2120,7 @@
                 bootbox.prompt({
                     title: "Choose Parent Project",
                     inputType: 'select',
-                    value: "{{ project.projects_parent_project_id }}",
+                    value: "{{ (project.projects_parent_project_id ?: '-1') }}",
                     inputOptions: [
                         {
                             text: 'No Parent',

--- a/html/admin/project/project_index.twig
+++ b/html/admin/project/project_index.twig
@@ -252,6 +252,9 @@
                                                         {% endif %}
                                                     </div>
                                                     <br/>
+                                                    {% if project.projects_parent_project_id and project.projects_status_follow_parent %}
+                                                    <div class="alert alert-info mb-1"><p>This sub-project is following the status of its parent project</p></div> 
+                                                    {% endif %}
                                                     <div class="alert" style="background-color: {{STATUSES[project.projects_status]["backgroundColour"] }}; color: {{ STATUSES[project.projects_status]["foregroundColour"] }};">
                                                         <h5><b>Status: </b>{{ STATUSES[project.projects_status]['name'] }}</h5>
                                                         {{ STATUSES[project.projects_status]['description'] }}
@@ -262,18 +265,24 @@
                                         <div class="card-footer">
                                             <div class="btn-group float-right">
                                                 <button type="button" class="btn btn-default quickAddCommentButton">New Comment</button>
-                                                {% if 29|instancePermissions %}
+                                                {% if 29|instancePermissions and not( project.projects_parent_project_id and project.projects_status_follow_parent) %}
                                                     <button type="button" class="btn btn-secondary" id="editProjectStatus">Change Status</button>
                                                 {% endif %}
                                                 <button type="button" class="btn btn-default dropdown-toggle dropdown-icon" data-toggle="dropdown">
                                                     <span class="sr-only">Toggle Dropdown</span>
                                                     <div class="dropdown-menu" role="menu">
                                                         {% if 21|instancePermissions %}
-                                                            {% if project.projects_parent_project_id == null %}
-                                                                <a class="dropdown-item" id="newSubProject">New Sub-Project</a>
-                                                            {% endif %}
                                                             {% if project.subProjects == null %}
                                                                 <a class="dropdown-item" id="assignParentProject">Assign Parent Project</a>
+                                                            {% endif %}
+                                                            {% if project.projects_parent_project_id == null %}
+                                                                <a class="dropdown-item" id="newSubProject">New Sub-Project</a>
+                                                            {% else %}
+                                                                {% if project.projects_status_follow_parent %}
+                                                                    <a class="dropdown-item" id="stopFollowParent">Stop Following Parent Status</a>
+                                                                {% else %}
+                                                                    <a class="dropdown-item" id="followParent">Follow Parent Status</a>
+                                                                {% endif %}
                                                             {% endif %}
                                                             {% if project.projects_parent_project_id == null or project.subProjects == null %}
                                                                 <div class="dropdown-divider"></div>
@@ -2136,6 +2145,23 @@
                         }
                     }
                 })
+            });
+
+            $("#followParent").click(function () {
+                ajaxcall("projects/followParentStatus.php", {
+                    "projects_id": "{{ project.projects_id }}",
+                    "follow": "true",
+                }, function (data) {
+                    window.location.reload();
+                });
+            });
+            $("#stopFollowParent").click(function () {
+                ajaxcall("projects/followParentStatus.php", {
+                    "projects_id": "{{ project.projects_id }}",
+                    "follow": "false",
+                }, function (data) {
+                    window.location.reload();
+                });
             });
             {% endif %}
 

--- a/html/admin/project/project_index.twig
+++ b/html/admin/project/project_index.twig
@@ -2120,6 +2120,7 @@
                 bootbox.prompt({
                     title: "Choose Parent Project",
                     inputType: 'select',
+                    value: "{{ project.projects_parent_project_id }}",
                     inputOptions: [
                         {
                             text: 'No Parent',


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

Allows subprojects to optionally follow the project status of their parent project

![image](https://user-images.githubusercontent.com/54247748/180606803-62a5bcd4-2d65-467c-94a0-28db25607305.png)

### References

Closes #307 
Documented in adam-rms/website#27

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`