### PR TITLE
Default opening calendar to earliest event in subproject calendars

### DIFF
--- a/html/admin/assets/widgets/calendar.twig
+++ b/html/admin/assets/widgets/calendar.twig
@@ -41,6 +41,7 @@
                     return "{{ LOCATION ? LOCATION.locations_name ~ ": " }}" + monthNames[date['date']['month']] + " " + date['date']['year'];
                 },
                 events : [
+                    {% set startDate = false %}
                     {% for project in projects %}
                         {% if project.projects_dates_use_start != null and project.projects_dates_use_end != null %}
                         {
@@ -51,6 +52,9 @@
                             backgroundColor: '{{ STATUSES[project.projects_status]["backgroundColour"] }}',
                             textColor    : '{{ STATUSES[project.projects_status]["foregroundColour"] }}'
                         },
+                            {% if startDate > project.projects_dates_use_start|date("c") or startDate == false %}
+                                {% set startDate = project.projects_dates_use_start|date("c") %}
+                            {% endif %}
                         {% endif %}
                         {%  for subproject in project.subProjects %}
                             {% if subproject.projects_dates_use_start != null and subproject.projects_dates_use_end != null %}
@@ -62,10 +66,16 @@
                                     backgroundColor: '{{ STATUSES[subproject.projects_status]["backgroundColour"] }}',
                                     textColor    : '{{ STATUSES[subproject.projects_status]["foregroundColour"] }}'
                                 },
+                                {% if startDate > subproject.projects_dates_use_start|date("c") or startDate == false %}
+                                    {% set startDate = subproject.projects_dates_use_start|date("c") %}
+                                {% endif %}
                             {% endif %}
                         {% endfor %}
                     {% endfor %}
                 ],
+                {% if useStartDate %}
+                initialDate: '{{ startDate|date("c") }}',
+                {% endif %}
                 weekNumbers: true,
                 {% if USERDATA.instance['instances_weekStartDates'] %}
                 weekNumberContent : function(week) {

--- a/html/admin/assets/widgets/calendar.twig
+++ b/html/admin/assets/widgets/calendar.twig
@@ -73,7 +73,7 @@
                         {% endfor %}
                     {% endfor %}
                 ],
-                {% if useStartDate %}
+                {% if useStartDate and startDate %}
                 initialDate: '{{ startDate|date("c") }}',
                 {% endif %}
                 weekNumbers: true,

--- a/html/admin/project/project_index.twig
+++ b/html/admin/project/project_index.twig
@@ -827,7 +827,7 @@
                             {% if project.subProjects %}
                                     <div class="card">
                                         <div class="card-body p-0">
-                                            {% embed 'assets/widgets/calendar.twig' with {"projects": project.subProjects } %}
+                                            {% embed 'assets/widgets/calendar.twig' with {"projects": project.subProjects, "useStartDate": true } %}
                                             {% endembed %}
                                         </div>
                                     </div>


### PR DESCRIPTION

### Description
Subproject calendars shouldn't start on the current day, as the projects will be at another time. With recent changes to the calendars, they are no longer limited to a set range so need to start on a set day

