### PR TITLE
Download images server-side for PDFs

### DIFF
--- a/html/admin/project/pdf.twig
+++ b/html/admin/project/pdf.twig
@@ -6,15 +6,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.6/vfs_fonts.min.js" integrity="sha512-P0bOMePRS378NwmPDVPU455C/TuxDS+8QwJozdc7PGgN8kLqR4ems0U/3DeJkmiE31749vYWHvBOtR+37qDCZQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script>
         var docDefinition = {
-            images: {
-                {% if USERDATA.instance.instances_logo and GET['instancelogo'] %}
-                    logo: "{{ USERDATA.instance.instances_logo|s3URL("medium")|escape("js") }}",
-                {% endif %}
-            },
             content: [
-                {% if USERDATA.instance.instances_logo and GET['instancelogo'] %}
+                {% if INSTANCELOGO %}
                 {
-                    image: 'logo',
+                    image: "{{ INSTANCELOGO|escape("js") }}",
                     width: 200,
                     margin: [157, 0, 0, 20]
                 },

--- a/html/admin/project/projectInvoice.php
+++ b/html/admin/project/projectInvoice.php
@@ -20,4 +20,8 @@ if ($count) $fileNumber = ($count+1);
 else $fileNumber = 1;
 $PAGEDATA['fileNumber'] = $fileNumber;
 
+if ($PAGEDATA['USERDATA']['instance']['instances_logo'] and $PAGEDATA['GET']['instancelogo']) {
+    $PAGEDATA['INSTANCELOGO'] = $bCMS->s3DataUri($PAGEDATA['USERDATA']['instance']['instances_logo'], "medium");
+} else $PAGEDATA['INSTANCELOGO'] = false;
+
 echo $TWIG->render('project/pdf.twig', $PAGEDATA);

--- a/html/common/coreHead.php
+++ b/html/common/coreHead.php
@@ -109,6 +109,10 @@ class bCMS {
         return $DBLIB->get("s3files", $limit, ["s3files_id", "s3files_extension", "s3files_name","s3files_meta_size", "s3files_meta_uploaded","s3files_shareKey"]);
     }
     function s3DataUri($fileid, $size = "comp") {
+        /**
+         * Returns a data URI for the file, upto a limit of 10MB. 
+         * The PDF library used to generate PDFs from HTML requires a data URI for images, so this is used to generate them. It can accept file URLs but misses the cors preflight when sending the request so fails CORS in the browser.
+         */
         $file = $this->s3Passthrough($fileid, $size);
         if (!$file) return false;
 

--- a/html/common/coreHead.php
+++ b/html/common/coreHead.php
@@ -108,13 +108,49 @@ class bCMS {
         $DBLIB->orderBy($sort, $sortOrder);
         return $DBLIB->get("s3files", $limit, ["s3files_id", "s3files_extension", "s3files_name","s3files_meta_size", "s3files_meta_uploaded","s3files_shareKey"]);
     }
+    function s3DataUri($fileid, $size = "comp") {
+        $file = $this->s3Passthrough($fileid, $size);
+        if (!$file) return false;
+
+        if ($file["type"] == "png") $type = "image/png";
+        elseif ($file["type"] == "jpg") $type = "image/jpeg";
+        elseif ($file["type"] == "jpeg") $type = "image/jpeg";
+        elseif ($file["type"] == "jfif") $type = "image/jpeg";
+        elseif ($file["type"] == "gif") $type = "image/gif";
+        elseif ($file["type"] == "heic") $type = "image/heic";
+        elseif ($file["type"] == "heif") $type = "image/heif";
+        else return false; // Only supports images
+
+        return 'data: '.$type.';base64,'.base64_encode($file['data']);
+    }
+    function s3Passthrough($fileid, $size = "comp") {
+        global $DBLIB;
+        $DBLIB->where("s3files_id", intval($fileid));
+        $DBLIB->where("(s3files_meta_deleteOn >= '". date("Y-m-d H:i:s") . "' OR s3files_meta_deleteOn IS NULL)"); //If the file is to be deleted soon or has been deleted don't let them download it
+        $DBLIB->where("s3files_meta_physicallyStored",1); //If we've lost the file or deleted it we can't actually let them download it
+        $DBLIB->where("s3files_meta_size", 10485760, "<="); //Limit files to 10mb for this function
+        $file = $DBLIB->getone("s3files", ["s3files_extension", "s3files_id"]);
+        if (!$file) return false;
+        
+        $url = $this->s3URL($file["s3files_id"], $size, false);
+        if (!$url) return false;
+        
+        $data = file_get_contents($url);
+        if (!$data) return false;
+
+        return [
+            "data" => $data,
+            "type" => $file["s3files_extension"],
+            "url" => $url
+        ];
+    }
     function s3URL($fileid, $size = "comp", $forceDownload = false, $expire = '+10 minutes', $shareKey = false) {
         global $DBLIB, $CONFIG,$AUTH;
         /*
          * File interface for Amazon AWS S3.
          *  Parameters
          *      f (required) - the file id as specified in the database
-         *      s (filesize) - false to get the original - available is "tiny" (100px) "small" (500px) "medium" (800px) "large" (1500px)
+         *      s (filesize) - false to get the original - available is "tiny" (100px) "small" (500px) "medium" (800px) "large" (1500px) "comp" (original size, compressed) "full" (original)
          *      d (optional, default false) - should a download be forced or should it be displayed in the browser? (if set it will download)
          *      e (optional, default 1 minute) - when should the link expire? Must be a string describing how long in words basically. If this file type has security features then it will default to 1 minute.
          */


### PR DESCRIPTION
We are getting bizare intermittent CORS issues where pdfmake is not sending a CORS preflight to AWS Cloudfront to download images. 

Workaround this by downloading the image server-side and data-uri encoding it