### PR TITLE
Stop infinite loops in Asset Linking

### DIFF
--- a/html/admin/api/projects/assets/assign.php
+++ b/html/admin/api/projects/assets/assign.php
@@ -40,9 +40,11 @@ $DBLIB->join("assetTypes","assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT
 $assetIDs = $DBLIB->get("assets", null, $assetRequiredFields);
 
 function linkedAssets($assetId,$linkCount) {
-    global $DBLIB,$assetsToProcess,$assetRequiredFields,$project;
-    $DBLIB->where("assets_linkedTo", $assetId);
-    $DBLIB->where("assets_deleted", 0);
+    global $DBLIB,$assetsToProcess,$assetRequiredFields,$project,$assetsLinked;
+    array_push($assetsLinked,$assetId);
+    $DBLIB->where("assets.assets_linkedTo", $assetId);
+    $DBLIB->where("assets.assets_id", $assetsLinked, "NOT IN"); // Make sure an asset is not double counted
+    $DBLIB->where("assets.assets_deleted", 0);
     $DBLIB->where("(assets.assets_endDate IS NULL OR assets.assets_endDate >= '" . $project["projects_dates_deliver_end"] . "')");
     $DBLIB->join("assetTypes","assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT");
     $assets = $DBLIB->get("assets",null,$assetRequiredFields);
@@ -53,6 +55,7 @@ function linkedAssets($assetId,$linkCount) {
     }
 }
 $assetsToProcess = [];
+$assetsLinked = [];
 foreach ($assetIDs as $asset) {
     $asset['linkedto'] = false;
     $assetsToProcess[] = $asset;

--- a/html/admin/asset.php
+++ b/html/admin/asset.php
@@ -102,9 +102,12 @@ if (count($PAGEDATA['assets']) == 1) {
     } else $PAGEDATA['assets'][0]['link'] = false;
 
     $PAGEDATA['assets'][0]['linkedToThis'] = [];
+    $assetsLinked = [];
     function linkedAssets($assetId,$tier) {
-        global $DBLIB,$PAGEDATA;
-        $DBLIB->where("assets_linkedTo", $assetId);
+        global $DBLIB,$PAGEDATA, $assetsLinked;
+        array_push($assetsLinked,$assetId);
+        $DBLIB->where("assets.assets_linkedTo", $assetId);
+        $DBLIB->where("assets.assets_id", $assetsLinked, "NOT IN"); // Make sure an asset is not double counted causing an infinite loop
         $DBLIB->join("assetTypes","assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT");
         $assets = $DBLIB->get("assets",null,["assets_tag","assets_id","assetTypes_name","assets.assetTypes_id"]);
         $tier+=1;
@@ -115,6 +118,7 @@ if (count($PAGEDATA['assets']) == 1) {
         }
     }
     linkedAssets($PAGEDATA['assets'][0]['assets_id'],0);
+    unset($assetsLinked);
 
     //Groups
     if ($PAGEDATA['assets'][0]['assets_assetGroups']) {


### PR DESCRIPTION
Stop asset linking from causing infinite loops