### PR TITLE
Add parent project to crew recruitment listings

### DIFF
--- a/html/admin/project/crew/vacancies.php
+++ b/html/admin/project/crew/vacancies.php
@@ -21,12 +21,22 @@ $DBLIB->orderBy("projectsVacantRoles.projectsVacantRoles_added","ASC");
 $roles = $DBLIB->get("projectsVacantRoles",null,["projectsVacantRoles.*","projects.*","users.users_userid", "users.users_name1", "users.users_name2", "users.users_email"]);
 $PAGEDATA['roles'] = [];
 foreach($roles as $role) {
+    //information about existing applications
     $DBLIB->where("projectsVacantRoles_id",$role['projectsVacantRoles_id']);
     $DBLIB->where("projectsVacantRolesApplications_deleted",0);
     $DBLIB->where("projectsVacantRolesApplications_withdrawn",0);
     $DBLIB->where("users_userid",$AUTH->data['users_userid']);
     $role['application'] = $DBLIB->getOne("projectsVacantRolesApplications",["projectsVacantRolesApplications_id"]);
     $role['projectsVacantRoles_questions'] = json_decode($role['projectsVacantRoles_questions'],true);
+
+    //get parent project if set
+    if ($role['projects_parent_project_id']) {
+        $DBLIB->where("projects_id",$role['projects_parent_project_id']);
+        $DBLIB->where("projects_deleted",0);
+        $DBLIB->where("projects_archived",0);
+        $role['parentProject'] = $DBLIB->getOne("projects",["projects_id","projects_name"]);
+    }
+
     $PAGEDATA['roles'][] = $role;
 }
 echo $TWIG->render('project/crew/vacancies.twig', $PAGEDATA);

--- a/html/admin/project/crew/vacancies.twig
+++ b/html/admin/project/crew/vacancies.twig
@@ -34,6 +34,9 @@
                 <tr>
                     <td>
                         {% if project != role.projects_id %}
+                            {% if role.parentProject %}
+                                {{role.parentProject.projects_name}} &rarr;
+                            {% endif %}
                             {{ role.projects_name }}
                         {% else %}
                             &#8627;
@@ -86,6 +89,9 @@
         <div class="card">
             <div class="card-header">
                 <h3 class="card-title">
+                        {% if role.parentProject %}
+                            {{role.parentProject.projects_name}} &rarr;
+                        {% endif %}
                         {{ role.projects_name }}
                 </h3>
             </div>
@@ -100,7 +106,8 @@
                         </p>
                         <p>
                             <strong>Project Dates: </strong>
-                            {{role.projects_dates_use_start ? role.projects_dates_use_start|date("d M Y h:ia") }} - 
+                            {{role.projects_dates_use_start ? role.projects_dates_use_start|date("d M Y h:ia") }}
+                            {{role.projects_dates_use_start and role.projects_dates_use_end ? " - " }} 
                             {{role.projects_dates_use_end ? role.projects_dates_use_end|date("d M Y h:ia") }}
                         </p>
                         {% if role.projectsVacantRoles_deadline %}


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

Adds the parent project name to crew recruitment listings where relevant

![image](https://user-images.githubusercontent.com/54247748/208298519-3fa59869-c2ea-4186-ada1-52d98a04fd3e.png)

### References

Closes #428 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`