### PR TITLE
Add location files button to sub-locations

### DIFF
--- a/html/admin/location/location_index.twig
+++ b/html/admin/location/location_index.twig
@@ -129,6 +129,9 @@
                                 </td>
                                 <td class="project-actions text-right">
                                     <div class="btn-group">
+                                        {% if 100|instancePermissions %}
+                                            <a href="{{ CONFIG.ROOTURL }}/location/?files&id={{ location.locations_id }}" type="button" class="btn btn-primary btn-sm">{{ (location.files|length > 0 ? location.files|length ~ '&nbsp;' : '')|raw }}<i class="fas fa-paperclip" style="display:inline;"></i></a>
+                                        {% endif %}
                                         {% if 103|instancePermissions %}
                                             <a href="{{ CONFIG.ROOTURL }}/location/barcode.php?location={{ subLocation.locations_id }}" type="button" class="btn btn-default btn-sm"><i class="fas fa-barcode"></i></a>
                                         {% endif %}

--- a/html/admin/location/location_index.twig
+++ b/html/admin/location/location_index.twig
@@ -130,7 +130,7 @@
                                 <td class="project-actions text-right">
                                     <div class="btn-group">
                                         {% if 100|instancePermissions %}
-                                            <a href="{{ CONFIG.ROOTURL }}/location/?files&id={{ location.locations_id }}" type="button" class="btn btn-primary btn-sm">{{ (location.files|length > 0 ? location.files|length ~ '&nbsp;' : '')|raw }}<i class="fas fa-paperclip" style="display:inline;"></i></a>
+                                            <a href="{{ CONFIG.ROOTURL }}/location/?files&id={{ subLocation.locations_id }}" type="button" class="btn btn-primary btn-sm">{{ (subLocation.files|length > 0 ? subLocation.files|length ~ '&nbsp;' : '')|raw }}<i class="fas fa-paperclip" style="display:inline;"></i></a>
                                         {% endif %}
                                         {% if 103|instancePermissions %}
                                             <a href="{{ CONFIG.ROOTURL }}/location/barcode.php?location={{ subLocation.locations_id }}" type="button" class="btn btn-default btn-sm"><i class="fas fa-barcode"></i></a>


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

All locations can have files associated with them, but sub-locations don't have an associated button for them. Adds this button

### References

Closes #397 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`