### PR TITLE
424 Custom Project Statuses

### DIFF
--- a/db/migrations/20230319174116_custom_project_status.php
+++ b/db/migrations/20230319174116_custom_project_status.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CustomProjectStatus extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        //add a custom project status column to the projects table
+        $this->table('projects')
+            ->addColumn('projects_customProjectStatus', 'string', [
+                'null' => true,
+                'after' => 'projects_status'
+            ])
+            ->save();
+    }
+}

--- a/html/admin/api/projects/changeStatus.php
+++ b/html/admin/api/projects/changeStatus.php
@@ -4,7 +4,12 @@ require_once __DIR__ . '/../apiHeadSecure.php';
 
 if (!$AUTH->instancePermissionCheck(29) or !isset($_POST['projects_id'])) die("404");
 
-function changeStatus($projectID, $status) {
+if (!isset($_POST['projects_status_custom'])) {
+    $_POST['projects_status_custom'] = null;
+}
+
+function changeStatus($projectID, $status, $customStatus = null)
+{
     global $DBLIB, $AUTH, $bCMS;
     $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
     $DBLIB->where("projects.projects_deleted", 0);
@@ -12,47 +17,56 @@ function changeStatus($projectID, $status) {
     $project = $DBLIB->getone("projects", ["projects_id", "projects_status","projects_dates_deliver_start","projects_dates_deliver_end"]);
     if (!$project) finish(false);
 
-    $thisStatus = $GLOBALS['STATUSES'][$project['projects_status']];
-    $newStatus = $GLOBALS['STATUSES'][$status];
-    if (!$newStatus) finish(false);
+    if ($status == "-1" and $customStatus) {
+        //Project has a custom status
+        $decodedStatus = json_decode($customStatus, true);
 
-    if ($thisStatus["assetsAvailable"] && $newStatus["assetsAvailable"] != true) {
-        //We're taking the project from a state where its assets had been released to a state where its assets are now locked down
-        $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
-        $DBLIB->where("assetsAssignments.projects_id", $project['projects_id']);
-        $assets = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assets_id", "assetsAssignments.assetsAssignments_id"]);
-        if ($assets) {
-            $unavailableAssets = [];
-            foreach ($assets as $asset) {
-                $DBLIB->where("assetsAssignments.assets_id", $asset['assets_id']);
-                $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
-                $DBLIB->where("projects.projects_status NOT IN (" . implode(",", $GLOBALS['STATUSES-AVAILABLE']) . ")");
-                $DBLIB->where("projects.projects_deleted", 0);
-                $DBLIB->join("projects", "assetsAssignments.projects_id=projects.projects_id", "LEFT");
-                $DBLIB->join("assets","assetsAssignments.assets_id=assets.assets_id", "LEFT");
-                $DBLIB->join("assetTypes", "assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT");
-                $DBLIB->where("((projects_dates_deliver_start >= '" . $project["projects_dates_deliver_start"]  . "' AND projects_dates_deliver_start <= '" . $project["projects_dates_deliver_end"] . "') OR (projects_dates_deliver_end >= '" . $project["projects_dates_deliver_start"] . "' AND projects_dates_deliver_end <= '" . $project["projects_dates_deliver_end"] . "') OR (projects_dates_deliver_end >= '" . $project["projects_dates_deliver_end"] . "' AND projects_dates_deliver_start <= '" . $project["projects_dates_deliver_start"] . "'))");
-                $assignment = $DBLIB->getone("assetsAssignments", null, ["assetsAssignments.assetsAssignments_id", "assetsAssignments.assets_id","assetsAssignments.projects_id", "assetTypes.assetTypes_name", "projects.projects_name", "assets.assets_tag"]);
-                if ($assignment) {
-                    $assignment['old_assetsAssignments_id'] = $asset['assetsAssignments_id'];
-                    $unavailableAssets[] = $assignment;
+        $DBLIB->where("projects.projects_id", $project['projects_id']);
+        $projectupdate =  $DBLIB->update("projects", ["projects.projects_status" => -1, "projects.projects_customProjectStatus" =>  $customStatus]);
+        if (!$projectupdate) finish(false);
+        $bCMS->auditLog("UPDATE-STATUS", "projects", "Set the status to " . htmlspecialchars($decodedStatus['name']) . " (A Custom Status)", $AUTH->data['users_userid'], null, $projectID);
+    } else {
+        $thisStatus = $GLOBALS['STATUSES'][$project['projects_status']];
+        $newStatus = $GLOBALS['STATUSES'][$status];
+        if (!$newStatus) finish(false);
+
+        if ($thisStatus["assetsAvailable"] && $newStatus["assetsAvailable"] != true) {
+            //We're taking the project from a state where its assets had been released to a state where its assets are now locked down
+            $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
+            $DBLIB->where("assetsAssignments.projects_id", $project['projects_id']);
+            $assets = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assets_id", "assetsAssignments.assetsAssignments_id"]);
+            if ($assets) {
+                $unavailableAssets = [];
+                foreach ($assets as $asset) {
+                    $DBLIB->where("assetsAssignments.assets_id", $asset['assets_id']);
+                    $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
+                    $DBLIB->where("projects.projects_status NOT IN (" . implode(",", $GLOBALS['STATUSES-AVAILABLE']) . ")");
+                    $DBLIB->where("projects.projects_deleted", 0);
+                    $DBLIB->join("projects", "assetsAssignments.projects_id=projects.projects_id", "LEFT");
+                    $DBLIB->join("assets", "assetsAssignments.assets_id=assets.assets_id", "LEFT");
+                    $DBLIB->join("assetTypes", "assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT");
+                    $DBLIB->where("((projects_dates_deliver_start >= '" . $project["projects_dates_deliver_start"]  . "' AND projects_dates_deliver_start <= '" . $project["projects_dates_deliver_end"] . "') OR (projects_dates_deliver_end >= '" . $project["projects_dates_deliver_start"] . "' AND projects_dates_deliver_end <= '" . $project["projects_dates_deliver_end"] . "') OR (projects_dates_deliver_end >= '" . $project["projects_dates_deliver_end"] . "' AND projects_dates_deliver_start <= '" . $project["projects_dates_deliver_start"] . "'))");
+                    $assignment = $DBLIB->getone("assetsAssignments", null, ["assetsAssignments.assetsAssignments_id", "assetsAssignments.assets_id", "assetsAssignments.projects_id", "assetTypes.assetTypes_name", "projects.projects_name", "assets.assets_tag"]);
+                    if ($assignment) {
+                        $assignment['old_assetsAssignments_id'] = $asset['assetsAssignments_id'];
+                        $unavailableAssets[] = $assignment;
+                    }
                 }
-            }
-            if (count($unavailableAssets) > 0) {
-                finish(true, null, ["changed" => false, "assets" => $unavailableAssets]);
+                if (count($unavailableAssets) > 0) {
+                    finish(true, null, ["changed" => false, "assets" => $unavailableAssets]);
+                }
             }
         }
 
+        $DBLIB->where("projects.projects_id", $project['projects_id']);
+        $projectupdate =  $DBLIB->update("projects", ["projects.projects_status" => $status]);
+        if (!$projectupdate) finish(false);
+        $bCMS->auditLog("UPDATE-STATUS", "projects", "Set the status to " . $GLOBALS['STATUSES'][$status]['name'], $AUTH->data['users_userid'], null, $projectID);
     }
-
-    $DBLIB->where("projects.projects_id", $project['projects_id']);
-    $projectupdate =  $DBLIB->update("projects", ["projects.projects_status" => $status]);
-    if (!$projectupdate) finish(false);
-    $bCMS->auditLog("UPDATE-STATUS", "projects", "Set the status to ". $GLOBALS['STATUSES'][$status]['name'], $AUTH->data['users_userid'],null, $projectID);
 }
 
 //update this project
-changeStatus($_POST['projects_id'],$_POST['projects_status']);
+changeStatus($_POST['projects_id'], $_POST['projects_status'], $_POST['projects_status_custom']);
 
 //Update any sub-projects that follow their parent project's status
 $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
@@ -62,7 +76,7 @@ $DBLIB->where("projects.projects_status_follow_parent", 1);
 $subProjects = $DBLIB->get("projects", null, ["projects_id"]);
 
 foreach ($subProjects as $key => $value) {
-    changeStatus($value['projects_id'],$_POST['projects_status']);
+    changeStatus($value['projects_id'], $_POST['projects_status'], $_POST['projects_status_custom']);
 }
 
 finish(true, null, ["changed" => true]);

--- a/html/admin/asset.php
+++ b/html/admin/asset.php
@@ -62,7 +62,12 @@ foreach ($assets as $asset) {
     $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
     $DBLIB->join("projects", "assetsAssignments.projects_id=projects.projects_id", "LEFT");
     $DBLIB->where("projects.projects_deleted", 0);
-    $asset['assignments'] = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.projects_id", "projects.projects_status", "projects.projects_name","projects_dates_deliver_start","projects_dates_deliver_end", "assetsAssignments.assetsAssignmentsStatus_id"]);
+    $asset['assignments'] = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.projects_id", "projects.projects_status", "projects.projects_customProjectStatus", "projects.projects_name", "projects_dates_deliver_start", "projects_dates_deliver_end", "assetsAssignments.assetsAssignmentsStatus_id"]);
+    foreach ($asset['assignments'] as $key => $assignment) {
+        if ($assignment['projects_status'] == -1) {
+            $asset['assignments'][$key]['projects_customProjectStatus'] = json_decode($assignment['projects_customProjectStatus'], true);
+        }
+    }
 
     $asset['files'] = $bCMS->s3List(4, $asset['assets_id']);
 

--- a/html/admin/asset.twig
+++ b/html/admin/asset.twig
@@ -224,12 +224,12 @@
                                             {% for thisasset in assets %}
                                             {% for assignment in thisasset.assignments %}
                                             {
-                                                title          : '{{ thisasset.assets_tag|aTag }} [{{ STATUSES[assignment.projects_status]["name"] }}] {{ assignment.projects_name }}',
+                                                title          : '{{ thisasset.assets_tag|aTag }} [{{ (assignment.projects_status == -1 ? assignment.projects_customProjectStatus["name"]  : STATUSES[assignment.projects_status]["name"]|escape("js")) }}] {{ assignment.projects_name }}',
                                                 start          : Date.parse("{{ assignment.projects_dates_deliver_start|date("c") }}"),
                                                 end            : Date.parse("{{ assignment.projects_dates_deliver_end|date("c") }}"),
                                                 url            : '{{CONFIG.ROOTURL}}/project/?id={{ assignment.projects_id }}',
-                                                backgroundColor: '{{ STATUSES[assignment.projects_status]["backgroundColour"] }}',
-                                                textColor    : '{{ STATUSES[assignment.projects_status]["foregroundColour"] }}'
+                                                backgroundColor: '{{ (assignment.projects_status == -1 ? assignment.projects_customProjectStatus["backgroundColour"]  : STATUSES[assignment.projects_status]["backgroundColour"]) }}',
+                                                textColor    : '{{ (assignment.projects_status == -1 ? assignment.projects_customProjectStatus["foregroundColour"]  : STATUSES[assignment.projects_status]["foregroundColour"]) }}'
                                             },
                                             {% if earliestStart > assignment.projects_dates_deliver_start|date("c") or earliestStart == false %}
                                             {% set earliestStart = assignment.projects_dates_deliver_start|date("c") %}
@@ -854,12 +854,12 @@
                                             {% for thisasset in assets %}
                                                 {% for assignment in thisasset.assignments %}
                                                 {
-                                                    title          : '[{{ STATUSES[assignment.projects_status]["name"] }}] {{ assignment.projects_name }}',
+                                                    title          : '[{{ (assignment.projects_status == -1 ? assignment.projects_customProjectStatus["name"]  : STATUSES[assignment.projects_status]["name"]|escape("js")) }}] {{ assignment.projects_name }}',
                                                     start          : Date.parse("{{ assignment.projects_dates_deliver_start|date("c") }}"),
                                                     end            : Date.parse("{{ assignment.projects_dates_deliver_end|date("c") }}"),
                                                     url            : '{{CONFIG.ROOTURL}}/project/?id={{ assignment.projects_id }}',
-                                                    backgroundColor: '{{ STATUSES[assignment.projects_status]["backgroundColour"] }}',
-                                                    textColor    : '{{ STATUSES[assignment.projects_status]["foregroundColour"] }}'
+                                                    backgroundColor: '{{ (assignment.projects_status == -1 ? assignment.projects_customProjectStatus["backgroundColour"]  : STATUSES[assignment.projects_status]["backgroundColour"]) }}',
+                                                    textColor    : '{{ (assignment.projects_status == -1 ? assignment.projects_customProjectStatus["foregroundColour"]  : STATUSES[assignment.projects_status]["foregroundColour"]) }}'
                                                 },
                                                 {% if earliestStart > assignment.projects_dates_deliver_start|date("c") or earliestStart == false %}
                                                     {% set earliestStart = assignment.projects_dates_deliver_start|date("c") %}

--- a/html/admin/assets/template.twig
+++ b/html/admin/assets/template.twig
@@ -630,8 +630,16 @@
                                         {% else %}
                                         far fa-circle
                                         {% endif %}
+                                        {% if project.projects_status != -1 %}
                                         text-{{ STATUSES[project.projects_status]['class'] }}
-                                        " title="{{ STATUSES[project.projects_status]['name'] }}"></i>
+                                        {% endif %}"
+                                        {% if project.projects_status == -1 %}
+                                        title="{{project.projects_customProjectStatus['name']}}"
+                                        style="color: {{project.projects_customProjectStatus['backgroundColour']}}"
+                                        {% else %}
+                                        title="{{ STATUSES[project.projects_status]['name'] }}"
+                                        {% endif %}
+                                        ></i>
                                     <p title="{{ project.projects_name }}">{{ project.projects_name|u.truncate(19, '...') }}</p>
                                     <i class="fas fa-angle-left right"></i>
                                 </a>
@@ -644,8 +652,16 @@
                                                 {% else %}
                                                 far fa-sun
                                                 {% endif %}
-                                        text-{{ STATUSES[project.projects_status]['class'] }}
-                                        " title="{{ STATUSES[project.projects_status]['name'] }}"></i>
+                                                {% if project.projects_status != -1 %}
+                                                text-{{ STATUSES[project.projects_status]['class'] }}
+                                                {% endif %}"
+                                                {% if project.projects_status == -1 %}
+                                                title="{{project.projects_customProjectStatus['name']}}"
+                                                style="color: {{project.projects_customProjectStatus['backgroundColour']}}"
+                                                {% else %}
+                                                title="{{ STATUSES[project.projects_status]['name'] }}"
+                                                {% endif %}
+                                            ></i>
                                             <p title="{{ project.projects_name }}">{{ project.projects_name|u.truncate(19, '...') }}</p>
                                         </a>
                                     </li>
@@ -653,13 +669,21 @@
                                         <li class="nav-item">
                                             <a href="{{ CONFIG.ROOTURL }}/project/?id={{ subProject.projects_id }}" class="nav-link">
                                                 <i class="nav-icon
-                                        {% if subProject.projects_manager == USERDATA.users_userid %}
-                                        fas fa-star
-                                        {% else %}
-                                        far fa-circle
-                                        {% endif %}
-                                        text-{{ STATUSES[subProject.projects_status]['class'] }}
-                                        " title="{{ STATUSES[subProject.projects_status]['name'] }}"></i>
+                                                    {% if subProject.projects_manager == USERDATA.users_userid %}
+                                                    fas fa-star
+                                                    {% else %}
+                                                    far fa-circle
+                                                    {% endif %}
+                                                    {% if subProject.projects_status != -1 %}
+                                                    text-{{ STATUSES[subProject.projects_status]['class'] }}
+                                                    {% endif %}"
+                                                    {% if subProject.projects_status == -1 %}
+                                                    title="{{subProject.projects_customProjectStatus['name']}}"
+                                                    style="color: {{subProject.projects_customProjectStatus['backgroundColour']}}"
+                                                    {% else %}
+                                                    title="{{ STATUSES[subProject.projects_status]['name'] }}"
+                                                    {% endif %}
+                                                ></i>
                                                 <p title="{{ subProject.projects_name }}">&#8627; {{ subProject.projects_name|u.truncate(19, '...') }}</p>
                                             </a>
                                         </li>
@@ -675,8 +699,16 @@
                                         {% else %}
                                         far fa-circle
                                         {% endif %}
+                                        {% if project.projects_status != -1 %}
                                         text-{{ STATUSES[project.projects_status]['class'] }}
-                                        " title="{{ STATUSES[project.projects_status]['name'] }}"></i>
+                                        {% endif %}"
+                                        {% if project.projects_status == -1 %}
+                                        title="{{project.projects_customProjectStatus['name']}}"
+                                        style="color: {{project.projects_customProjectStatus['backgroundColour']}}"
+                                        {% else %}
+                                        title="{{ STATUSES[project.projects_status]['name'] }}"
+                                        {% endif %}
+                                    ></i>
                                     <p title="{{ project.projects_name }}">{{ project.projects_name|u.truncate(24, '...') }}</p>
                                 </a>
                             </li>

--- a/html/admin/assets/widgets/calendar.twig
+++ b/html/admin/assets/widgets/calendar.twig
@@ -45,12 +45,12 @@
                     {% for project in projects %}
                         {% if project.projects_dates_use_start != null and project.projects_dates_use_end != null %}
                         {
-                            title          : "[{{ STATUSES[project.projects_status]["name"]|escape("js") }}] {{ project.clients_name ? project.clients_name|escape("js") ~ " - " }}{{ project.projects_name|escape("js") }}",
+                            title          : "[{{(project.projects_status == -1 ? project.projects_customProjectStatus['name']  : STATUSES[project.projects_status]["name"]|escape("js")) }}] {{ project.clients_name ? project.clients_name|escape("js") ~ " - " }}{{ project.projects_name|escape("js") }}",
                             start          : {{ project.projects_dates_use_start|date('U') }}*1000,
                             end            : {{ project.projects_dates_use_end|date('U') }}*1000,
                             url            : '{{CONFIG.ROOTURL}}/project/?id={{ project.projects_id }}',
-                            backgroundColor: '{{ STATUSES[project.projects_status]["backgroundColour"] }}',
-                            textColor    : '{{ STATUSES[project.projects_status]["foregroundColour"] }}'
+                            backgroundColor: '{{ (project.projects_status == -1 ? project.projects_customProjectStatus['backgroundColour']  : STATUSES[project.projects_status]["backgroundColour"])}}',
+                            textColor    : '{{ (project.projects_status == -1 ? project.projects_customProjectStatus['foregroundColour']  : STATUSES[project.projects_status]["foregroundColour"])}}'
                         },
                             {% if startDate > project.projects_dates_use_start|date("c") or startDate == false %}
                                 {% set startDate = project.projects_dates_use_start|date("c") %}
@@ -59,12 +59,12 @@
                         {%  for subproject in project.subProjects %}
                             {% if subproject.projects_dates_use_start != null and subproject.projects_dates_use_end != null %}
                                 {
-                                    title          : "↳ [{{ STATUSES[subproject.projects_status]["name"]|escape("js") }}] {{ subproject.clients_name ? subproject.clients_name|escape("js") ~ " - " }}{{ subproject.projects_name|escape("js") }}",
+                                    title          : "↳ [{{ (subproject.projects_status == -1 ? subproject.projects_customProjectStatus['name']  : STATUSES[subproject.projects_status]["name"]|escape("js"))}}] {{ subproject.clients_name ? subproject.clients_name|escape("js") ~ " - " }}{{ subproject.projects_name|escape("js") }}",
                                     start          : {{ subproject.projects_dates_use_start|date('U') }}*1000,
                                     end            : {{ subproject.projects_dates_use_end|date('U') }}*1000,
                                     url            : '{{CONFIG.ROOTURL}}/project/?id={{ subproject.projects_id }}',
-                                    backgroundColor: '{{ STATUSES[subproject.projects_status]["backgroundColour"] }}',
-                                    textColor    : '{{ STATUSES[subproject.projects_status]["foregroundColour"] }}'
+                                    backgroundColor: '{{ (subproject.projects_status == -1 ? subproject.projects_customProjectStatus['backgroundColour']  : STATUSES[subproject.projects_status]["backgroundColour"])}}',
+                                    textColor    : '{{ (subproject.projects_status == -1 ? subproject.projects_customProjectStatus['foregroundColour']  : STATUSES[subproject.projects_status]["foregroundColour"])}}'
                                 },
                                 {% if startDate > subproject.projects_dates_use_start|date("c") or startDate == false %}
                                     {% set startDate = subproject.projects_dates_use_start|date("c") %}

--- a/html/admin/common/headSecure.php
+++ b/html/admin/common/headSecure.php
@@ -83,6 +83,7 @@ if ($PAGEDATA['USERDATA']['users_changepass'] == 1) {
         }
     }
     foreach ($projects as $index=>$project) { //Loop back throuhg the projects once more and join the subprojects up with their parents, preserving sorting again
+        $project['projects_customProjectStatus'] = json_decode($project['projects_customProjectStatus'], true);
         if ($project['projects_parent_project_id'] != null and isset($tempProjectKeys[$project['projects_parent_project_id']])) {
             $PAGEDATA['projects'][$tempProjectKeys[$project['projects_parent_project_id']]]['subProjects'][] = $project;
         }

--- a/html/admin/common/headSecure.php
+++ b/html/admin/common/headSecure.php
@@ -70,10 +70,12 @@ if ($PAGEDATA['USERDATA']['users_changepass'] == 1) {
     $DBLIB->orderBy("projects.projects_dates_deliver_start", "ASC");
     $DBLIB->orderBy("projects.projects_name", "ASC");
     $DBLIB->orderBy("projects.projects_created", "ASC");
-    $projects = $DBLIB->get("projects", null, ["projects_id", "projectsTypes.*","projects_archived", "projects_name", "clients_name", "projects_dates_deliver_start", "projects_dates_deliver_end","projects_dates_use_start", "projects_dates_use_end", "projects_status", "projects_manager", "projects_parent_project_id"]);
+    $projects = $DBLIB->get("projects", null, ["projects_id", "projectsTypes.*", "projects_archived", "projects_name", "clients_name", "projects_dates_deliver_start", "projects_dates_deliver_end", "projects_dates_use_start", "projects_dates_use_end", "projects_status", "projects_customProjectStatus", "projects_manager", "projects_parent_project_id"]);
     $PAGEDATA['projects'] = [];
     $tempProjectKeys = []; //Track the Project IDs of all projects and their place in the array (allows us to preserve sorting)
     foreach ($projects as $index=>$project) {
+        $project['projects_customProjectStatus'] = json_decode($project['projects_customProjectStatus'], true);
+        
         if ($project['projects_parent_project_id'] == null) {
             $project['subProjects'] = [];
             $tempProjectKeys[$project['projects_id']] = count($PAGEDATA['projects']);

--- a/html/admin/project/index.php
+++ b/html/admin/project/index.php
@@ -7,6 +7,11 @@ require_once __DIR__ . '/../api/projects/data.php'; //Where most of the data com
 if ($PAGEDATA['project']['projects_status'] == -1) {
     $PAGEDATA['project']['projects_customProjectStatus'] = json_decode($PAGEDATA['project']['projects_customProjectStatus'], true);
 }
+foreach ($PAGEDATA['project']['subProjects'] as $index => $subProject) {
+    if ($subProject['projects_status'] == -1) {
+        $PAGEDATA['project']['subProjects'][$index]['projects_customProjectStatus'] = json_decode($subProject['projects_customProjectStatus'], true);
+    }
+}
 
 //AuditLog
 $DBLIB->where("auditLog.auditLog_deleted", 0);

--- a/html/admin/project/index.php
+++ b/html/admin/project/index.php
@@ -3,6 +3,11 @@ require_once __DIR__ . '/../common/headSecure.php';
 if (!$AUTH->instancePermissionCheck(20) or !isset($_GET['id'])) die($TWIG->render('404.twig', $PAGEDATA));
 require_once __DIR__ . '/../api/projects/data.php'; //Where most of the data comes from
 
+//Decode custom status
+if ($PAGEDATA['project']['projects_status'] == -1) {
+    $PAGEDATA['project']['projects_customProjectStatus'] = json_decode($PAGEDATA['project']['projects_customProjectStatus'], true);
+}
+
 //AuditLog
 $DBLIB->where("auditLog.auditLog_deleted", 0);
 $DBLIB->where("auditLog.projects_id", $PAGEDATA['project']['projects_id']);

--- a/html/admin/project/list.php
+++ b/html/admin/project/list.php
@@ -47,13 +47,14 @@ $DBLIB->orderBy("projects.projects_archived", "ASC");
 $DBLIB->orderBy("projects.projects_dates_use_start", "ASC");
 $DBLIB->orderBy("projects.projects_name", "ASC");
 $DBLIB->orderBy("projects.projects_created", "ASC");
-$projectlist = $DBLIB->arraybuilder()->paginate("projects", $page, ["projects_id", "projectsTypes.*","projects_archived", "projects_name", "clients_name", "projects.clients_id", "projects_dates_deliver_start", "projects_dates_deliver_end","projects_dates_use_start", "projects_dates_use_end", "projects_status", "projects_manager", "users.users_name1", "users.users_name2", "users.users_email", "users.users_thumbnail"]);
+$projectlist = $DBLIB->arraybuilder()->paginate("projects", $page, ["projects_id", "projectsTypes.*", "projects_archived", "projects_name", "clients_name", "projects.clients_id", "projects_dates_deliver_start", "projects_dates_deliver_end", "projects_dates_use_start", "projects_dates_use_end", "projects_status", "projects_customProjectStatus", "projects_manager", "users.users_name1", "users.users_name2", "users.users_email", "users.users_thumbnail"]);
 $PAGEDATA['pagination'] = ["page" => $page, "total" => $DBLIB->totalPages];
 $PAGEDATA['PROJECTSLIST'] = [];
 foreach ($projectlist as $project) {
     $DBLIB->where("projects_id", $project['projects_id']);
     $DBLIB->orderBy("projectsFinanceCache_timestamp", "DESC");
     $project['finance'] = $DBLIB->getOne("projectsFinanceCache");
+    $project['projects_customProjectStatus'] = json_decode($project['projects_customProjectStatus'], true);
 
     $DBLIB->where("projects_parent_project_id", $project['projects_id']);
     $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
@@ -64,9 +65,10 @@ foreach ($projectlist as $project) {
     $DBLIB->orderBy("projects.projects_dates_use_start", "ASC");
     $DBLIB->orderBy("projects.projects_name", "ASC");
     $DBLIB->orderBy("projects.projects_created", "ASC");
-    $subProjects = $DBLIB->get("projects", null, ["projects_id", "projectsTypes.*","projects_archived", "projects_name", "clients_name", "projects.clients_id", "projects_dates_deliver_start", "projects_dates_deliver_end","projects_dates_use_start", "projects_dates_use_end", "projects_status", "projects_manager", "users.users_name1", "users.users_name2", "users.users_email", "users.users_thumbnail"]);
+    $subProjects = $DBLIB->get("projects", null, ["projects_id", "projectsTypes.*", "projects_archived", "projects_name", "clients_name", "projects.clients_id", "projects_dates_deliver_start", "projects_dates_deliver_end", "projects_dates_use_start", "projects_dates_use_end", "projects_status", "projects_customProjectStatus", "projects_manager", "users.users_name1", "users.users_name2", "users.users_email", "users.users_thumbnail"]);
     $project['subProjects'] = [];
     foreach ($subProjects as $subProject) {
+        $subProject['projects_customProjectStatus'] = json_decode($subProject['projects_customProjectStatus'], true);
         $DBLIB->where("projects_id", $project['projects_id']);
         $DBLIB->orderBy("projectsFinanceCache_timestamp", "DESC");
         $subProject['finance'] = $DBLIB->getOne("projectsFinanceCache");

--- a/html/admin/project/project_index.twig
+++ b/html/admin/project/project_index.twig
@@ -248,10 +248,17 @@
                                                     {% if project.projects_parent_project_id and project.projects_status_follow_parent %}
                                                     <div class="alert alert-info mb-1"><p>This sub-project is following the status of its parent project</p></div> 
                                                     {% endif %}
+                                                    {% if project.projects_status == -1 %}
+                                                    <div class="alert" style="background-color: {{project.projects_customProjectStatus["backgroundColour"] }}; color: {{ project.projects_customProjectStatus["foregroundColour"] }};">
+                                                        <h5><b>Status: </b>{{ project.projects_customProjectStatus['name'] }}</h5>
+                                                        {{ project.projects_customProjectStatus['description'] }}
+                                                    </div>
+                                                    {% else %}
                                                     <div class="alert" style="background-color: {{STATUSES[project.projects_status]["backgroundColour"] }}; color: {{ STATUSES[project.projects_status]["foregroundColour"] }};">
                                                         <h5><b>Status: </b>{{ STATUSES[project.projects_status]['name'] }}</h5>
                                                         {{ STATUSES[project.projects_status]['description'] }}
                                                     </div>
+                                                    {% endif %}
                                                 </div>
                                             </div>
                                         </div>
@@ -259,7 +266,7 @@
                                             <div class="btn-group float-right">
                                                 <button type="button" class="btn btn-default quickAddCommentButton">New Comment</button>
                                                 {% if 29|instancePermissions and not( project.projects_parent_project_id and project.projects_status_follow_parent) %}
-                                                    <button type="button" class="btn btn-secondary" id="editProjectStatus">Change Status</button>
+                                                    <button type="button" class="btn btn-secondary" id="editProjectStatus" data-toggle="modal" data-target="#projectStatusModal">Change Status</button>
                                                 {% endif %}
                                                 <button type="button" class="btn btn-default dropdown-toggle dropdown-icon" data-toggle="dropdown">
                                                     <span class="sr-only">Toggle Dropdown</span>
@@ -1314,7 +1321,104 @@
             </form>
         </div>
     </div>
+    <div class="modal fade" id="projectStatusModal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Set Project Status</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="projectStatusModal-preset">Preset Statuses</label>
+                        <select class="form-control" id="projectStatusModal-preset">
+                            {% for id,status in STATUSES %}
+                                <option value='{{ id }}' {{(id == project.projects_status ? 'selected' : '')}}>
+                                    {{status.name ~ ' (' ~ status.description ~ ')'}}
+                                </option>
+                            {% endfor %}
+                            <option value='-1' {{(-1 == project.projects_status ? 'selected' : '')}}>Custom</option>
+                        </select>
+                    </div>
+                    <hr />
+                    <div class="form-group">
+                        <label for="projectStatusModal-name">Status Name</label>
+                        <input 
+                            type="text" 
+                            class="form-control" 
+                            id="projectStatusModal-name" 
+                            placeholder="Status Name" 
+                            value="{{project.projects_status == -1 ? project.projects_customProjectStatus['name'] : STATUSES[project.projects_status]['name'] }}"
+                            {{project.projects_status == -1 ? '' : 'disabled'}}
+                        />
+                    </div>
+                    <div class="form-group">
+                        <label for="projectStatusModal-description">Status Description</label>
+                        <input 
+                            type="text" 
+                            class="form-control" 
+                            id="projectStatusModal-description" 
+                            placeholder="Status Description" 
+                            value="{{project.projects_status == -1 ? project.projects_customProjectStatus['description'] : STATUSES[project.projects_status]['description'] }}"
+                            {{project.projects_status == -1 ? '' : 'disabled'}}
+                        />
+                    </div>
+                    <div class="form-group">
+                        <label for="projectStatusModal-colour">Status Background Colour</label>
+                        <input 
+                            type="color" 
+                            class="form-control" 
+                            id="projectStatusModal-colour" 
+                            value="{{project.projects_status == -1 ? project.projects_customProjectStatus['backgroundColour'] : STATUSES[project.projects_status]['backgroundColour'] }}"
+                            {{project.projects_status == -1 ? '' : 'disabled'}}
+                        />
+                    </div>
+                    <hr />
+                    {% if project.projects_status == -1 %}
+                    <div class="alert" id="projectStatusModal-summary" style="background-color: {{project.projects_customProjectStatus["backgroundColour"] }}; color: {{ project.projects_customProjectStatus["foregroundColour"] }};">
+                        <h5><b>Status: </b><span id="projectStatusModal-summary-name">{{ project.projects_customProjectStatus['name'] }}</span></h5>
+                        <span id="projectStatusModal-summary-description">{{ project.projects_customProjectStatus['description'] }}</span>
+                    </div>
+                    {% else %}
+                    <div class="alert" id="projectStatusModal-summary" style="background-color: {{STATUSES[project.projects_status]["backgroundColour"] }}; color: {{ STATUSES[project.projects_status]["foregroundColour"] }};">
+                        <h5><b>Status: </b><span id="projectStatusModal-summary-name">{{ STATUSES[project.projects_status]['name'] }}</span></h5>
+                        <span id="projectStatusModal-summary-description">{{ STATUSES[project.projects_status]['description'] }}</span>
+                    </div>
+                    {% endif %}
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="projectStatusModal-submit">OK</button>
+                </div>
+            </div>
+        </div>
+    </div>
     <script>
+        let statuses = {
+            {% for id,status in STATUSES %}
+                {{ id }} : {
+                    name: '{{ status.name }}',
+                    description: '{{ status.description }}',
+                    backgroundColour: '{{ status.backgroundColour }}',
+                    foregroundColour: '{{ status.foregroundColour }}'
+                },
+            {% endfor %}
+        };
+
+        function getForegroundColour(backgroundColour) {
+            // Check colour contrast of background colour to decide foreground colour
+            var c = backgroundColour.substring(1);      // strip #
+            var rgb = parseInt(c, 16);   // convert rrggbb to decimal
+            var r = (rgb >> 16) & 0xff;  // extract red
+            var g = (rgb >>  8) & 0xff;  // extract green
+            var b = (rgb >>  0) & 0xff;  // extract blue
+            var brightness = 0.2126 * r + 0.7152 * g + 0.0722 * b; // per ITU-R BT.709
+
+            return (brightness > 125) ? '#000000' : '#FFFFFF';
+        }
+
         $(document).ready(function () {
             $('#pdfGenerateModal').on('show.bs.modal', function (e) {
                 if ($(e.relatedTarget).data('quote')) {
@@ -1656,17 +1760,24 @@
             });
             {% endif %}
             {% if 29|instancePermissions %}
-            function changeStatus(newStatus) {
+            /**
+             * Change the status of the project
+             * @param newStatus {number | "custom"} - ID of the status 
+             * @param customStatus {json} - JSON object of the custom status
+             */
+            function changeStatus(newStatus, customStatus) {
+
                 ajaxcall("projects/changeStatus.php", {
                     "projects_status": newStatus,
-                    "projects_id": "{{ project.projects_id }}"
+                    "projects_id": "{{ project.projects_id }}",
+                    "projects_status_custom": customStatus
                 }, function (data) {
                     if (data.response.changed) {
                         location.reload();
                     } else {
                         var message = "The status of this project can't be changed because assets assigned to it have been assigned to other projects that clash. <br/><br/> Would you like to automatically remove the following assets from this project? This will have billing implications<br/><br/><br/><table class='table table-bordered'><tr><th>Tag</th><th>Name</th><th>Project Clashing</th></tr>";
                         $.each(data.response.assets, function( index, value ) {
-                            message += "<tr><td>A-" + value['assets_tag'] + "</td><td>" + value['assetTypes_name'] + "</td><td>" + value['projects_name'] + "</td></tr>";
+                            message += "<tr><td>" + value['assets_tag'] + "</td><td>" + value['assetTypes_name'] + "</td><td>" + value['projects_name'] + "</td></tr>";
                         });
                         bootbox.confirm({
                             message: message + "</table>",
@@ -1684,14 +1795,17 @@
                                 if (result) {
                                     {% if 31|instancePermissions %}
                                     var toRemove = [];
-                                    console.log(data.response.assets);
                                     $.each(data.response.assets, function( index, value ) {
                                         toRemove.push(value['old_assetsAssignments_id']);
                                     });
                                     ajaxcall("projects/assets/unassign.php", {
                                         "assetsAssignments": toRemove
                                         }, function (data) {
-                                            changeStatus(newStatus);
+                                            if (newStatus == "custom") {
+                                                changeStatus(newStatus, customStatus);
+                                            } else {
+                                                changeStatus(newStatus);
+                                            }
                                         });
                                     {% else %}
                                     bootbox.alert("Sorry - you don't have permission to remove these assets");
@@ -1702,47 +1816,72 @@
                     }
                 });
             }
-            $("#editProjectStatus").click(function () {
-                bootbox.prompt({
-                    title: "Set project status",
-                    inputType: 'select',
-                    value: {{ project.projects_status }},
-                    inputOptions: [
-                        {% for id,status in STATUSES %}
-                        {
-                            text: "{{ (status.name ~ " (" ~ status.description ~ ')')|escape('js') }}",
-                            value: '{{ id }}',
+
+            //update status preview on change
+            $("#projectStatusModal-preset").change(function () {
+                const newStatus = $(this).val();
+                if (newStatus != "-1") {
+                    //Using a preset, so disable the name and description fields
+                    $('#projectStatusModal-name, #projectStatusModal-description, #projectStatusModal-colour').prop( "disabled", true );
+                    //Set values based on the preset
+                    $('#projectStatusModal-name').val(statuses[newStatus].name);
+                    $('#projectStatusModal-summary-name').html(statuses[newStatus].name);
+
+                    $('#projectStatusModal-description').val(statuses[newStatus].description);
+                    $('#projectStatusModal-summary-description').html(statuses[newStatus].description);
+
+                    $('#projectStatusModal-colour').val(statuses[newStatus].backgroundColour);
+                    $('#projectStatusModal-summary').css({"backgroundColor": statuses[newStatus].backgroundColour,"color":statuses[newStatus].foregroundColour });
+                } else {
+                    //using a custom status, so enable the name and description fields
+                    $('#projectStatusModal-name, #projectStatusModal-description, #projectStatusModal-colour').prop( "disabled", false );
+                }
+            });
+            //custom preset updates, based on the values in the fields
+            $('#projectStatusModal-name').on("input", function () {
+                $('#projectStatusModal-summary-name').html($(this).val());
+            });
+            $('#projectStatusModal-description').on("input", function () {
+                $('#projectStatusModal-summary-description').html($(this).val());
+            });
+            $("#projectStatusModal-colour").on("input", function () {
+                $('#projectStatusModal-summary').css({"backgroundColor": $(this).val(), "color": getForegroundColour($(this).val()) });
+            });
+
+            $("#projectStatusModal-submit").click(function () {
+                const newStatus = $("#projectStatusModal-preset").val();
+                if (newStatus == "-1"){
+                    const customStatus = {
+                        "name": $('#projectStatusModal-name').val(),
+                        "description": $('#projectStatusModal-description').val(),
+                        "backgroundColour": $('#projectStatusModal-colour').val(),
+                        "foregroundColour": getForegroundColour($('#projectStatusModal-colour').val())
+                    };
+                    const encodedStatus = JSON.stringify(customStatus);
+                    changeStatus(newStatus, encodedStatus);
+
+                } else if ([{{ STATUSESAVAILABLE|join(",") }}].includes(parseInt(newStatus))) {
+                    bootbox.confirm({
+                        message: "This will allow assets assigned to this project to be assigned to other clashing projects - are you sure you wish to continue?",
+                        buttons: {
+                            confirm: {
+                                label: 'Yes',
+                                className: 'btn-danger'
+                            },
+                            cancel: {
+                                label: 'No',
+                                className: 'btn-success'
+                            }
                         },
-                        {% endfor %}
-                    ],
-                    callback: function (result) {
-                        if (result) {
-                            var newStatus = result;
-                            if ([{{ STATUSESAVAILABLE|join(",") }}].includes(parseInt(newStatus))) {
-                                bootbox.confirm({
-                                    message: "This will allow assets assigned to this project to be assigned to other clashing projects - are you sure you wish to continue?",
-                                    buttons: {
-                                        confirm: {
-                                            label: 'Yes',
-                                            className: 'btn-danger'
-                                        },
-                                        cancel: {
-                                            label: 'No',
-                                            className: 'btn-success'
-                                        }
-                                    },
-                                    callback: function (result) {
-                                        if (result) {
-                                            changeStatus(newStatus);
-                                        }
-                                    }
-                                });
-                            } else {
+                        callback: function (result) {
+                            if (result) {
                                 changeStatus(newStatus);
                             }
                         }
-                    }
-                });
+                    });
+                } else {
+                    changeStatus(newStatus);
+                }
             });
             {% endif %}
             {% if 30|instancePermissions %}

--- a/html/admin/project/project_list.twig
+++ b/html/admin/project/project_list.twig
@@ -107,6 +107,12 @@
                             {% endif %}
                         </td>
                         <td class="project_progress">
+                            {% if project.projects_status == -1 %}
+                            {{ project.projects_customProjectStatus['name'] }}<br/>
+                            <small>
+                                {{ project.projects_customProjectStatus['description'] }}
+                            </small>
+                            {% else %}
                             {{ STATUSES[project.projects_status]['name'] }}<br/>
                             {% if STATUSES[project.projects_status]['order'] < 7 %}
                                 <div class="progress progress-sm">
@@ -117,6 +123,7 @@
                             <small>
                                 {{ STATUSES[project.projects_status]['description'] }}
                             </small>
+                            {% endif %}
                         </td>
                     </tr>
                     {% if project.subProjects %}

--- a/html/admin/project/project_list.twig
+++ b/html/admin/project/project_list.twig
@@ -176,16 +176,23 @@
                                     {% endif %}
                                 </td>
                                 <td class="project_progress">
+                                    {% if subProject.projects_status == -1 %}
+                                    {{ subProject.projects_customProjectStatus['name'] }}<br/>
+                                    <small>
+                                        {{ subProject.projects_customProjectStatus['description'] }}
+                                    </small>
+                                    {% else %}
                                     {{ STATUSES[subProject.projects_status]['name'] }}<br/>
                                     {% if STATUSES[subProject.projects_status]['order'] < 7 %}
                                         <div class="progress progress-sm">
-                                            <div class="progress-bar" style="color: {{ STATUSES[project.projects_status]['foregroundColour'] }}!important;background-color: {{ STATUSES[project.projects_status]['backgroundColour']}}!important;width: {{ ((STATUSES[project.projects_status]['order']/6)*100)|round }}%;" role="progressbar" aria-volumenow="{{ STATUSES[subProject.projects_status]['order'] }}" aria-volumemin="0" aria-volumemax="6">
+                                            <div class="progress-bar" style="color: {{ STATUSES[subProject.projects_status]['foregroundColour'] }}!important;background-color: {{ STATUSES[subProject.projects_status]['backgroundColour']}}!important;width: {{ ((STATUSES[subProject.projects_status]['order']/6)*100)|round }}%;" role="progressbar" aria-volumenow="{{ STATUSES[subProject.projects_status]['order'] }}" aria-volumemin="0" aria-volumemax="6">
                                             </div>
                                         </div>
                                     {% endif %}
                                     <small>
                                         {{ STATUSES[subProject.projects_status]['description'] }}
                                     </small>
+                                    {% endif %}
                                 </td>
                             </tr>
                         {% endfor %}


### PR DESCRIPTION
### Description

Updates the change project status popup to include custom project status options.
Statuses can now be either a "preset" status (existing statuses) or a custom one created by the project Manager

![image](https://user-images.githubusercontent.com/54247748/226216969-fdbf042d-3806-4257-811c-2fa8f11e9cf6.png)

Popup includes a preview of the status, so that colour schemes can be checked before updating the status.


### References

Closes #424 

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`