### PR TITLE
Tweak Token Authentication again

### DIFF
--- a/html/admin/api/login/authStep2Password.php
+++ b/html/admin/api/login/authStep2Password.php
@@ -37,16 +37,9 @@ if (isset($_POST['formInput']) and isset($_POST['password'])) {
         elseif ($user['users_emailVerified'] != 1) finish(false, ["code" => "VERIFYEMAIL", "message" => "Please verify your email address using the link we sent you to login","userid" => $user['users_userid']]);
 		else {
             if (!$_SESSION['return'] and isset($_SESSION['app-oauth'])) {
-                //Duplicated in index.php
-                $token = $GLOBALS['AUTH']->generateToken($user['users_userid'], false, null, true, "App OAuth");
-                $jwt = JWT::encode(array(
-                    "iss" => $CONFIG['ROOTURL'],
-                    "uid" => $user['users_userid'],
-                    "token" => $token,
-                    "exp" => time()+21*24*60*60, //21 days token expiry
-                    "iat" => time()
-                ), $CONFIG['JWTKey']);
-                finish(true,null,["redirect" => $_SESSION['app-oauth'] . "://oauth_callback?token=" . $jwt]);
+                $_SESSION['oauth2']['userid'] = $user['users_userid'];
+                finish(true, null, ["redirect" => $CONFIG['ROOTURL'] . "/login/?oauth-confirm=true"]);
+
             } else {
                 $GLOBALS['AUTH']->generateToken($user['users_userid'], false);
                 finish(true,null,["redirect" => (isset($_SESSION['return']) ? $_SESSION['return'] : $CONFIG['ROOTURL'])]);

--- a/html/admin/api/login/oauth2.php
+++ b/html/admin/api/login/oauth2.php
@@ -17,11 +17,13 @@ if ($_SESSION['app-oauth'] == "v2") {
   $baseLocation = $_SESSION['app-oauth'] . 'oauth_callback?legacy=true';
 }
 
-if ($_SESSION['app-oauth']['userid'] && isset($_GET['approved'])) {
-  $token = $GLOBALS['AUTH']->generateToken($_SESSION['app-oauth']['userid'], false, null, true, "App OAuth2");
+error_log("Base Location: " . $baseLocation);
+
+if ($_SESSION['oauth2']['userid'] && isset($_GET['approved'])) {
+  $token = $GLOBALS['AUTH']->generateToken($_SESSION['oauth2']['userid'], false, null, true, "App OAuth2");
   $jwt = JWT::encode(array(
     "iss" => $CONFIG['ROOTURL'],
-    "uid" => $_SESSION['app-oauth']['userid'],
+    "uid" => $_SESSION['oauth2']['userid'],
     "token" => $token,
     "exp" => time() + 21 * 24 * 60 * 60, //21 days token expiry
     "iat" => time()

--- a/html/admin/api/login/oauth2.php
+++ b/html/admin/api/login/oauth2.php
@@ -1,0 +1,41 @@
+<?php
+require_once 'loginAjaxHead.php';
+
+use \Firebase\JWT\JWT;
+
+$baseLocation = $CONFIG['ROOTURL'];
+if (!isset(($_SESSION['app-oauth'])) || !isset($_SESSION['oauth2'])) {
+  //We're not using an app, so just redirect to the root
+  header("Location: " . $CONFIG['ROOTURL']);
+}
+
+if ($_SESSION['app-oauth'] == "v2") {
+  //we're logging in using the V2 App
+  $baseLocation = $_SESSION['oauth2']['redirect_uri'] . "/?state=" . $_SESSION['oauth2']['state'];
+} else {
+  //Legacy App
+  $baseLocation = $_SESSION['app-oauth'] . 'oauth_callback?legacy=true';
+}
+
+if ($_SESSION['app-oauth']['userid'] && isset($_GET['approved'])) {
+  $token = $GLOBALS['AUTH']->generateToken($_SESSION['app-oauth']['userid'], false, null, true, "App OAuth2");
+  $jwt = JWT::encode(array(
+    "iss" => $CONFIG['ROOTURL'],
+    "uid" => $_SESSION['app-oauth']['userid'],
+    "token" => $token,
+    "exp" => time() + 21 * 24 * 60 * 60, //21 days token expiry
+    "iat" => time()
+  ), $CONFIG['JWTKey']);
+
+  //unset the session oauth now its used
+  $_SESSION['app-oauth'] = null;
+
+  header("Location: " . $baseLocation . "&token=" . $jwt);
+  exit;
+} else {
+  if (isset($_GET['end_session'])) {
+    $AUTH->logout();
+  }
+  header("Location: " . $baseLocation . "&error=access_denied");
+  exit;
+}

--- a/html/admin/api/login/oauth2.php
+++ b/html/admin/api/login/oauth2.php
@@ -17,8 +17,6 @@ if ($_SESSION['app-oauth'] == "v2") {
   $baseLocation = $_SESSION['app-oauth'] . 'oauth_callback?legacy=true';
 }
 
-error_log("Base Location: " . $baseLocation);
-
 if ($_SESSION['oauth2']['userid'] && isset($_GET['approved'])) {
   $token = $GLOBALS['AUTH']->generateToken($_SESSION['oauth2']['userid'], false, null, true, "App OAuth2");
   $jwt = JWT::encode(array(

--- a/html/admin/login/index.php
+++ b/html/admin/login/index.php
@@ -6,7 +6,7 @@ use \Firebase\JWT\JWT;
 $PAGEDATA['pageConfig'] = ["TITLE" => "Login"];
 
 if (isset($_GET['oauth-confirm']) && isset($_SESSION['oauth2'])) {
-	$PAGEDATA['oauth2']['client_id'] = $_SESSION['app-oauth']['client_id'];
+	$PAGEDATA['oauth2']['client_id'] = $_SESSION['oauth2']['client_id'];
 	//We've just logged in and want to give permission to the app
 	echo $TWIG->render('login/oauth-confirm.twig', $PAGEDATA);
 	exit;
@@ -36,6 +36,7 @@ if (isset($_GET['oauth-confirm']) && isset($_SESSION['oauth2'])) {
 
 	if ($GLOBALS['AUTH']->login) {
 		if ($_SESSION['app-oauth'] == "v2") {
+			$_SESSION['oauth2']['userid'] = $AUTH->data['users_userid'];
 			//We're already logged in so get permission to use the account
 			echo $TWIG->render('login/oauth-confirm.twig', $PAGEDATA);
 			exit;

--- a/html/admin/login/oauth-confirm.twig
+++ b/html/admin/login/oauth-confirm.twig
@@ -1,0 +1,13 @@
+{% extends "login/login_template.twig" %}
+{% block content %}
+<div>
+  <h1 class="h3">An application would like to connect to your account</h1>
+  <p>This will give this application full access to your AdamRMS account.</p>
+  <p>Application Client ID: <i>{{ oauth2.client_id }}</i></p>
+
+  <p class="h3">Allow access?<p>
+  <a class="btn btn-danger" href="/api/login/oauth2.php?end_session=true">Deny &amp; Log Out</a>
+  <a class="btn btn-warning" href="/api/login/oauth2.php">Deny</a>
+  <a class="btn btn-success" href="/api/login/oauth2.php?approved=true">Allow</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

* Adds state variable to the auth flow to get a bit closer to OAuth2 spec
* Adds Application connection page to confirm the app connection.

![image](https://user-images.githubusercontent.com/54247748/229303963-d7d65313-d8a5-4be1-997c-26eba08cd450.png)

#### Auth Flow

1. Application makes a request to ``/login`` with the following parameters:

  - app-oauth="v2"
  - redirect_uri: string, an application return address (eg com.bstudios.adamrms)
  - state: string, a string for the server to return to the application for CSRF
  - client_id: string, A (unique?) string that identifies the application to the users

2. User is authenticated using exising login methods
3. User is redirected to new ``oauth-confirm`` screen to allow the app connection (screenshot above)
4. Server returns token and state string to application

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`