### PR TITLE
Add all assets of an asset type to a project at once

### DIFF
--- a/html/admin/api/projects/assets/assign.php
+++ b/html/admin/api/projects/assets/assign.php
@@ -29,6 +29,7 @@ if (isset($_POST['assetGroups_id'])) {
 
     $DBLIB->where("FIND_IN_SET(" . $group['assetGroups_id'] . ", assets.assets_assetGroups)");
 } elseif (isset($_POST['assets_id'])) $DBLIB->where("assets_id", $_POST['assets_id']);
+elseif (isset($_POST['assetTypes_id'])) $DBLIB->where("assets.assetTypes_id", $_POST['assetTypes_id']);
 elseif ($AUTH->instancePermissionCheck("PROJECTS:PROJECT_ASSETS:CREATE:ASSIGN_ALL_BUSINESS_ASSETS")) {
     $DBLIB->where("(assets_linkedTo IS NULL)"); //We'll handle linked assets later in the script but for now add all assets
     $DBLIB->where("assets.instances_id", $AUTH->data['instance']['instances_id']);

--- a/html/admin/api/projects/assets/unassign.php
+++ b/html/admin/api/projects/assets/unassign.php
@@ -2,7 +2,8 @@
 require_once __DIR__ . '/../../apiHeadSecure.php';
 use Money\Currency;
 use Money\Money;
-if (!$AUTH->instancePermissionCheck("PROJECTS:PROJECT_ASSETS:CREATE:ASSIGN_AND_UNASSIGN") or (!isset($_POST['assetsAssignments']) and !isset($_POST['assets_id']))) die("404");
+
+if (!$AUTH->instancePermissionCheck("PROJECTS:PROJECT_ASSETS:CREATE:ASSIGN_AND_UNASSIGN") or (!isset($_POST['assetsAssignments']) and !isset($_POST['assets_id']) and !isset($_POST['assetTypes_id']))) die("404");
 
 if (isset($_POST['assets_id']) and isset($_POST['projects_id']) and !isset($_POST['assetsAssignments'])) {
     //Convert for where only the asset id and project is known
@@ -12,6 +13,17 @@ if (isset($_POST['assets_id']) and isset($_POST['projects_id']) and !isset($_POS
     $assignment = $DBLIB->getone("assetsAssignments", ["assetsAssignments_id"]);
     if ($assignment) $_POST['assetsAssignments'] = [$assignment['assetsAssignments_id']];
     else finish(false,["message"=>"Could not find assignment"]);
+}
+
+if (isset($_POST['assetTypes_id']) and isset($_POST['projects_id']) and !isset($_POST['assetsAssignments'])) {
+    //convert for where we only know assetType ID and project
+    $DBLIB->join("assets", "assetsAssignments.assets_id=assets.assets_id");
+    $DBLIB->where("assets.assetTypes_id", $_POST['assetTypes_id']);
+    $DBLIB->where("assetsAssignments.projects_id", $_POST['projects_id']);
+    $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
+    $assignments = $DBLIB->get("assetsAssignments", null, ["assetsAssignments_id"]);
+    if ($assignments) $_POST['assetsAssignments'] = array_column($assignments, "assetsAssignments_id");
+    else finish(false, ["message" => "Could not find Assignment"]);
 }
 
 $assignmentsRemove = new assetAssignmentSelector($_POST['assetsAssignments']);

--- a/html/admin/assets.php
+++ b/html/admin/assets.php
@@ -206,9 +206,11 @@ foreach ($assets as $asset) {
         if ($thisWhere) $DBLIB->where($thisWhere . ")",$thisValues);
     }
     $DBLIB->orderBy("assets.assets_tag", "ASC");
-    $assetTags = $DBLIB->get("assets", null, ["assets_id", "assets_notes","assets_tag","asset_definableFields_1","asset_definableFields_2","asset_definableFields_3","asset_definableFields_4","asset_definableFields_5","asset_definableFields_6","asset_definableFields_7","asset_definableFields_8","asset_definableFields_9","asset_definableFields_10","assets_dayRate","assets_weekRate","assets_value","assets_mass","assets_endDate"]);
+    $assetTags = $DBLIB->get("assets", null, ["assets_id", "assets_notes", "assets_tag", "asset_definableFields_1", "asset_definableFields_2", "asset_definableFields_3", "asset_definableFields_4", "asset_definableFields_5", "asset_definableFields_6", "asset_definableFields_7", "asset_definableFields_8", "asset_definableFields_9", "asset_definableFields_10", "assets_dayRate", "assets_weekRate", "assets_value", "assets_mass", "assets_endDate"]);
     if (!$assetTags) continue;
     $asset['count'] = count($assetTags);
+    $asset['countBlocked'] = 0;
+    $asset['countAvailable'] = 0;
     $asset['fields'] = explode(",", $asset['assetTypes_definableFields']);
     $asset['thumbnail'] = $bCMS->s3List(2, $asset['assetTypes_id'],'s3files_meta_uploaded','ASC',1);
     $asset['tags'] = [];
@@ -228,11 +230,13 @@ foreach ($assets as $asset) {
             $tag['assignment'] = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assetsAssignments_id", "assetsAssignments.projects_id", "projects.projects_name"]);
         }
         $tag['flagsblocks'] = assetFlagsAndBlocks($tag['assets_id']);
+        if ($tag['assignment'] or $tag['flagsblocks']['COUNT']['BLOCK'] > 0) $asset['countBlocked']++;
         $asset['tags'][] = $tag;
     }
+    $asset['countAvailable'] = $asset['count'] - $asset['countBlocked'];
     $RETURN['ASSETS'][] = $asset;
 }
-$RETURN['SPEED'] = microtime (true)-$scriptStartTime;
+$RETURN['SPEED'] = microtime(true) - $scriptStartTime;
 
 
 $PAGEDATA['searchOptions'] = [];
@@ -276,5 +280,4 @@ if (count($SEARCH['TERMS']['CATEGORY']) > 0) {
 
 $RETURN['SEARCH'] = $SEARCH;
 $PAGEDATA['searchResults'] = $RETURN;
-
 echo $TWIG->render('assets.twig', $PAGEDATA);

--- a/html/admin/assets.twig
+++ b/html/admin/assets.twig
@@ -272,7 +272,10 @@
                                                                             <th>&pound;/day</th>
                                                                             <th>&pound;/week</th>
                                                                             <th style="width:1%"><i class="fas fa-flag"></i></th>
-                                                                            <th style="width:30px;"></th>
+                                                                            <th style="width:30px;">
+                                                                                <button class="btn btn-success addToBasketAssetTypeButton {% if asset.countAvailable < 1 %} d-none {% endif %}" title "Add all of this asset type to the project" data-assetTypeId="{{ asset.assetTypes_id }}"><i class="fas fa-dolly"></i></button>
+                                                                                <button class="btn btn-warning removeFromBasketAssetTypeButton {% if asset.countAvailable > 0 %} d-none {% endif %}" title="Remove all of this asset type" data-assetTypeId="{{ asset.assetTypes_id }}"><i class="fas fa-dolly"></i></button>
+                                                                            </th>
                                                                         </tr>
                                                                         {% for thisasset in asset.tags %}
                                                                             <tr>
@@ -299,7 +302,7 @@
                                                                                             {%  if thisasset.assignment and searchResults.PROJECT.ID != thisasset.assignment[0].projects_id %}
                                                                                                 <button title="Assigned to {{ thisasset.assignment[0]['projects_name'] }}" class="btn btn-sm btn-success" disabled><i class="fa fa-shopping-basket"></i></button>
                                                                                             {% endif %}
-                                                                                            <button title="Add to project" {% if thisasset.assignment %} style="display:none;"{% else %}{% set someassignable = true %}{% endif %} class="btn btn-sm btn-success addToBasketAssetButton" data-assetid="{{ thisasset['assets_id'] }}"><i class="fa fa-shopping-basket"></i></button>
+                                                                                            <button title="Add to project" {% if thisasset.assignment %} style="display:none;"{% endif %} class="btn btn-sm btn-success addToBasketAssetButton" data-assetid="{{ thisasset['assets_id'] }}"><i class="fa fa-shopping-basket"></i></button>
                                                                                         {% else %}
                                                                                             <button class="btn btn-sm btn-danger" title="Asset is blocked from being assigned by a maintenance job" disabled><i class="fas fa-ban"></i></button>
                                                                                         {% endif %}
@@ -312,7 +315,7 @@
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <button type="button" class="btn btn-sm {{ someassignable ? 'btn-success' : 'btn-warning' }}" data-toggle="modal" data-target="#assetDetailsModal{{ asset.assetTypes_id }}"><i class="fa fa-shopping-basket"></i></button>
+                                                    <button type="button" class="btn btn-sm {{ asset.countAvailable > 0 ? 'btn-success' : 'btn-warning' }}" data-toggle="modal" data-target="#assetDetailsModal{{ asset.assetTypes_id }}"><i class="fa fa-shopping-basket"></i></button>
                                                 {% endif %}
                                             {% elseif searchResults.PROJECT.DATESTART and searchResults.PROJECT.DATEEND %}
                                                 {% if asset.count == 1 %}
@@ -625,6 +628,12 @@ $(document).ready(function () {
             });
         });
     });
+    $(".addToBasketAssetTypeButton").click(function () {
+        var assetTypeId = $(this).data("assettypeid");
+        ajaxcall("projects/assets/assign.php", {"assetTypes_id":assetTypeId,"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
+            window.location.reload();
+        });
+    });
     $(".removeFromBasketAssetButton").click(function () {
         var assetId = $(this).data("assetid");
         bootbox.confirm({
@@ -648,6 +657,29 @@ $(document).ready(function () {
                             type: 'success',
                             title: 'Removed from {{ searchResults.PROJECT.NAME }}'
                         });
+                    });
+                }
+            }
+        });
+    });
+    $(".removeFromBasketAssetTypeButton").click(function () {
+        var assetTypesId = $(this).data("assettypeid");
+        bootbox.confirm({
+            message: "Are you sure you wish to remove these assets from the project?",
+            buttons: {
+                confirm: {
+                    label: 'Yes',
+                    className: 'btn-danger'
+                },
+                cancel: {
+                    label: 'No',
+                    className: 'btn-success'
+                }
+            },
+            callback: function (result) {
+                if (result) {
+                    ajaxcall("projects/assets/unassign.php", {"assetTypes_id":assetTypesId,"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
+                        window.location.reload();
                     });
                 }
             }

--- a/html/admin/assets.twig
+++ b/html/admin/assets.twig
@@ -251,7 +251,6 @@
                                                         <button class="btn btn-sm btn-danger" title="Asset is blocked from being assigned by a maintenance job" disabled><i class="fas fa-ban"></i></button>
                                                     {% endif %}
                                                 {% else %}
-                                                    {% set someassignable = false %}
                                                     <div class="modal fade" id="assetDetailsModal{{ asset.assetTypes_id }}">
                                                         <div class="modal-dialog modal-xl">
                                                             <div class="modal-content">
@@ -331,7 +330,6 @@
                                                         <button class="btn btn-sm btn-danger" title="Asset is blocked from being assigned by a maintenance job" disabled><i class="fas fa-ban"></i></button>
                                                     {% endif %}
                                                 {% else %}
-                                                    {% set someassignable = false %}
                                                     <div class="modal fade" id="assetDetailsModal{{ asset.assetTypes_id }}">
                                                         <div class="modal-dialog modal-xl">
                                                             <div class="modal-content">
@@ -378,7 +376,7 @@
                                                                                             {%  if thisasset.assignment %}
                                                                                                 <button title="Assigned to {{ thisasset.assignment[0]['projects_name'] }}" class="btn btn-sm btn-danger" disabled><i class="fa fa-times"></i></button>
                                                                                             {% else %}
-                                                                                            <button title="Available" {% set someassignable = true %} class="btn btn-sm btn-success" disabled><i class="fa fa-check"></i></button>
+                                                                                            <button title="Available" class="btn btn-sm btn-success" disabled><i class="fa fa-check"></i></button>
                                                                                             {% endif %}
                                                                                         {% else %}
                                                                                             <button class="btn btn-sm btn-danger" title="Asset is blocked from being assigned by a maintenance job" disabled><i class="fas fa-ban"></i></button>
@@ -392,7 +390,7 @@
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <button type="button" class="btn btn-sm {{ someassignable ? 'btn-success' : 'btn-warning' }}" data-toggle="modal" data-target="#assetDetailsModal{{ asset.assetTypes_id }}"><i class="fa fa-calendar"></i></button>
+                                                    <button type="button" class="btn btn-sm {{ asset.countAvailable > 0 ? 'btn-success' : 'btn-warning' }}" data-toggle="modal" data-target="#assetDetailsModal{{ asset.assetTypes_id }}"><i class="fa fa-calendar"></i></button>
                                             {% endif %}
                                         {% endif %}
                                             <a href="{{ CONFIG.ROOTURL }}/asset.php?id={{ asset.assetTypes_id }}{{ asset.count == 1 ? '&asset=' ~ asset.tags[0]['assets_id'] : '' }}{{ SEARCH["SETTINGS"]["SHOWARCHIVED"] ? '&showArchived' : ''}}&instance={{ searchResults.SEARCH.INSTANCE_ID }}" class="btn btn-sm btn-default" target="_blank">

--- a/html/admin/assets.twig
+++ b/html/admin/assets.twig
@@ -272,8 +272,7 @@
                                                                             <th>&pound;/week</th>
                                                                             <th style="width:1%"><i class="fas fa-flag"></i></th>
                                                                             <th style="width:30px;">
-                                                                                <button class="btn btn-success addToBasketAssetTypeButton {% if asset.countAvailable < 1 %} d-none {% endif %}" title "Add all of this asset type to the project" data-assetTypeId="{{ asset.assetTypes_id }}"><i class="fas fa-dolly"></i></button>
-                                                                                <button class="btn btn-warning removeFromBasketAssetTypeButton {% if asset.countAvailable > 0 %} d-none {% endif %}" title="Remove all of this asset type" data-assetTypeId="{{ asset.assetTypes_id }}"><i class="fas fa-dolly"></i></button>
+                                                                                <button class="btn btn-success addToBasketAssetTypeButton" {% if asset.countAvailable < 1 %} disabled {% endif %}" title "Add all of this asset type to the project" data-assetTypeId="{{ asset.assetTypes_id }}"><i class="fas fa-dolly"></i></button>
                                                                             </th>
                                                                         </tr>
                                                                         {% for thisasset in asset.tags %}
@@ -297,11 +296,11 @@
                                                                                         {% if thisasset.assets_endDate != null and thisasset.assets_endDate < searchResults.PROJECT['DATEEND'] %}
                                                                                             <button title="Asset to be removed" class="btn btn-sm btn-success" disabled><i class="fa fa-shopping-basket"></i></button>
                                                                                         {% elseif thisasset.flagsblocks.COUNT.BLOCK < 1 %}
-                                                                                            <button title="Remove from project" {% if (not thisasset.assignment) or searchResults.PROJECT.ID != thisasset.assignment[0].projects_id %}style="display:none;"{% endif %} class="btn btn-sm btn-warning removeFromBasketAssetButton" data-assetid="{{ thisasset['assets_id'] }}"><i class="fa fa-shopping-basket"></i></button>
+                                                                                            <button title="Remove from project" {% if (not thisasset.assignment) or searchResults.PROJECT.ID != thisasset.assignment[0].projects_id %}style="display:none;"{% endif %} class="btn btn-sm btn-warning removeFromBasketAssetButton" data-assetid="{{ thisasset['assets_id'] }}" data-assetTypeId="{{ asset.assetTypes_id }}"><i class="fa fa-shopping-basket"></i></button>
                                                                                             {%  if thisasset.assignment and searchResults.PROJECT.ID != thisasset.assignment[0].projects_id %}
                                                                                                 <button title="Assigned to {{ thisasset.assignment[0]['projects_name'] }}" class="btn btn-sm btn-success" disabled><i class="fa fa-shopping-basket"></i></button>
                                                                                             {% endif %}
-                                                                                            <button title="Add to project" {% if thisasset.assignment %} style="display:none;"{% endif %} class="btn btn-sm btn-success addToBasketAssetButton" data-assetid="{{ thisasset['assets_id'] }}"><i class="fa fa-shopping-basket"></i></button>
+                                                                                            <button title="Add to project" {% if thisasset.assignment %} style="display:none;"{% endif %} class="btn btn-sm btn-success addToBasketAssetButton" data-assetid="{{ thisasset['assets_id'] }}" data-assetTypeId="{{ asset.assetTypes_id }}"><i class="fa fa-shopping-basket"></i></button>
                                                                                         {% else %}
                                                                                             <button class="btn btn-sm btn-danger" title="Asset is blocked from being assigned by a maintenance job" disabled><i class="fas fa-ban"></i></button>
                                                                                         {% endif %}
@@ -627,9 +626,16 @@ $(document).ready(function () {
         });
     });
     $(".addToBasketAssetTypeButton").click(function () {
-        var assetTypeId = $(this).data("assettypeid");
+        const thisButton = $(this);
+        var assetTypeId = thisButton.data("assettypeid");
         ajaxcall("projects/assets/assign.php", {"assetTypes_id":assetTypeId,"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
-            window.location.reload();
+            $(".addToBasketAssetButton[data-assettypeid=" + assetTypeId + "]").hide();
+            $(".removeFromBasketAssetButton[data-assettypeid=" + assetTypeId + "]").show();
+            thisButton.prop('disabled', true);
+            Toast.fire({
+                type: 'success',
+                title: 'Added to {{ searchResults.PROJECT.NAME }}'
+            });
         });
     });
     $(".removeFromBasketAssetButton").click(function () {
@@ -655,29 +661,6 @@ $(document).ready(function () {
                             type: 'success',
                             title: 'Removed from {{ searchResults.PROJECT.NAME }}'
                         });
-                    });
-                }
-            }
-        });
-    });
-    $(".removeFromBasketAssetTypeButton").click(function () {
-        var assetTypesId = $(this).data("assettypeid");
-        bootbox.confirm({
-            message: "Are you sure you wish to remove these assets from the project?",
-            buttons: {
-                confirm: {
-                    label: 'Yes',
-                    className: 'btn-danger'
-                },
-                cancel: {
-                    label: 'No',
-                    className: 'btn-success'
-                }
-            },
-            callback: function (result) {
-                if (result) {
-                    ajaxcall("projects/assets/unassign.php", {"assetTypes_id":assetTypesId,"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
-                        window.location.reload();
                     });
                 }
             }


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

Adds a new button to the Asset shopping popup to add all of one type of asset to the selected project.

### References

Closes #468 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`