### PR TITLE
Change "Apply" to "Sign Up" for FCFS vacancies

### DIFF
--- a/html/admin/project/crew/vacancies.twig
+++ b/html/admin/project/crew/vacancies.twig
@@ -67,7 +67,13 @@
                             {% if role.application %}
                                 <button type="button" class="btn btn-default btn-sm" disabled>Applied</button>
                             {% else %}
-                                <a type="button" class="btn btn-default btn-sm" href="{{CONFIG.ROOTURL}}/project/crew/vacancy.php?id={{ role.projectsVacantRoles_id }}">Apply</a>
+                                <a type="button" class="btn btn-default btn-sm" href="{{CONFIG.ROOTURL}}/project/crew/vacancy.php?id={{ role.projectsVacantRoles_id }}">
+                                    {% if role.projectsVacantRoles_firstComeFirstServed %}
+                                    Sign Up
+                                    {% else %}
+                                    Apply
+                                    {% endif %}
+                                </a>
                             {% endif %}
                         </div>
                     </td>

--- a/html/admin/project/crew/vacancy.twig
+++ b/html/admin/project/crew/vacancy.twig
@@ -105,7 +105,11 @@
             <form class="applyForm" data-id="{{ role.projectsVacantRoles_id }}">
                 <div class="card-header">
                     <h3 class="card-title">
+                        {% if role.projectsVacantRoles_firstComeFirstServed %}
+                        Sign Up
+                        {% else %}
                         Apply
+                        {% endif %}
                     </h3>
                 </div>
                 <div class="card-body">
@@ -190,13 +194,23 @@
                     {% endif %}
                 </div>
                 <div class="card-footer justify-content-between">
-                    <button type="submit" class="btn btn-success">Apply</button>
+                    <button type="submit" class="btn btn-success">
+                    {% if role.projectsVacantRoles_firstComeFirstServed %}
+                    Sign Up
+                    {% else %}
+                    Apply
+                    {% endif %}
+                    </button>
                 </div>
             </form>
             {% else %}
             <div class="card-header">
                 <h3 class="card-title">
+                    {% if role.projectsVacantRoles_firstComeFirstServed %}
+                    Sign Up
+                    {% else %}
                     Apply
+                    {% endif %}
                 </h3>
             </div>
             <div class="card-body">

--- a/html/admin/project/project_crew.twig
+++ b/html/admin/project/project_crew.twig
@@ -101,7 +101,14 @@
                             </p>
                             <div class="project-actions text-center">
                                 <div class="btn-group">
-                                    <a type="button" class="btn btn-default btn-sm" href="{{CONFIG.ROOTURL}}/project/crew/vacancy.php?id={{ role.projectsVacantRoles_id }}&from=project">More Info and Apply</a>
+                                    <a type="button" class="btn btn-default btn-sm" href="{{CONFIG.ROOTURL}}/project/crew/vacancy.php?id={{ role.projectsVacantRoles_id }}&from=project">
+                                        More Info and
+                                        {% if role.projectsVacantRoles_firstComeFirstServed %}
+                                        Sign Up
+                                        {% else %}
+                                        Apply
+                                        {% endif %}
+                                    </a>
                                 </div>
                             </div>
                         </div>      


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

This PR changes the label of the "Apply" button for first-come-first-served crew vacancies to "Sign Up", making it clearer that the role is FCFS, as previously the UX was slightly confusing (you'd "apply" for a role only to get it immediately), and having an "application" step could be off-putting.

### Testing

Run an AdamRMS instance, create a project, and add two crew vacancies, one FCFS and one non-FCFS. Verify the global Crew Vacancies page, as well as the project's Crew page, show "Sign Up" rather than "Apply".

<img width="786" alt="image" src="https://github.com/adam-rms/adam-rms/assets/2904440/9cc53513-57d9-414a-a2cc-60fb79c73ee8">
<img width="1549" alt="image" src="https://github.com/adam-rms/adam-rms/assets/2904440/67a1bc0a-e373-4d28-8b2f-7a64ec2ced96">


### Checklist

- [n/a] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`