### PR TITLE
Check for group visibility on project page listing

### DIFF
--- a/html/admin/project/index.php
+++ b/html/admin/project/index.php
@@ -71,6 +71,7 @@ if ($AUTH->instancePermissionCheck("PROJECTS:PROJECT_CREW:VIEW:VIEW_AND_APPLY_FO
     $DBLIB->where("(projectsVacantRoles.projectsVacantRoles_deadline IS NULL OR projectsVacantRoles.projectsVacantRoles_deadline >= '" . date("Y-m-d H:i:s") . "')");
     $DBLIB->where("(projectsVacantRoles.projectsVacantRoles_slots > projectsVacantRoles.projectsVacantRoles_slotsFilled)");
     $DBLIB->where("projectsVacantRoles.projects_id", $PAGEDATA['project']['projects_id']);
+    if ($AUTH->data['instance']["instancePositions_id"]) $DBLIB->where("(projectsVacantRoles.projectsVacantRoles_visibleToGroups IS NULL OR (FIND_IN_SET(" . $AUTH->data['instance']["instancePositions_id"] . ", projectsVacantRoles.projectsVacantRoles_visibleToGroups) > 0))"); //If the user doesn't have a position - they're server admins
     $PAGEDATA['crewRecruitment'] = $DBLIB->get("projectsVacantRoles");
 }
 


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

Fixes bug with project crew vacancy listing on a project page where users could see crew vacancies even if that listing was only visible to user groups that a given user was not in.

### References

Closes #488 

### Testing
Tested in development and staging environments

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`