### PR TITLE
Allow reopening applications after removing crew from role

### DIFF
--- a/db/migrations/20230913103712_crew_assignment_projectvacantrole.php
+++ b/db/migrations/20230913103712_crew_assignment_projectvacantrole.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CrewAssignmentProjectVacantRole extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $this->table('crewAssignments')
+            ->addColumn('projectsVacantRoles_id', 'integer', [
+                "null" => true,
+                "default" => null,
+                "after" => "crewAssignments_rank",
+            ])
+            ->addForeignKey('projectsVacantRoles_id', 'projectsVacantRoles', 'projectsVacantRoles_id', [
+                'constraint' => 'crewAssignments_projectsVacantRoles_id_fk',
+                'update' => 'CASCADE',
+                'delete' => 'SET NULL',
+            ])
+            ->save();
+    }
+}

--- a/html/admin/api/projects/crew/crewRoles/accept.php
+++ b/html/admin/api/projects/crew/crewRoles/accept.php
@@ -17,7 +17,8 @@ if (!$application) finish(false,["message"=>"Application not found"]);
 $insert = $DBLIB->insert("crewAssignments", [
     "projects_id" => $application["projects_id"],
     "users_userid" => $application['users_userid'],
-    "crewAssignments_role" => $application['projectsVacantRoles_name']
+    "crewAssignments_role" => $application['projectsVacantRoles_name'],
+    "projectsVacantRoles_id" => $application['projectsVacantRoles_id'],
 ]);
 if (!$insert) finish(false, ["message"=>"Could not assign this user to the role"]);
 

--- a/html/admin/api/projects/crew/crewRoles/apply.php
+++ b/html/admin/api/projects/crew/crewRoles/apply.php
@@ -46,7 +46,8 @@ if ($role['projectsVacantRoles_firstComeFirstServed']) {
     $insert = $DBLIB->insert("crewAssignments", [
         "projects_id" => $role["projects_id"],
         "users_userid" => $AUTH->data['users_userid'],
-        "crewAssignments_role" => $role['projectsVacantRoles_name']
+        "crewAssignments_role" => $role['projectsVacantRoles_name'],
+        "projectsVacantRoles_id" => $role['projectsVacantRoles_id'],
     ]);
     if (!$insert) finish(false, ["message"=>"Application received, but there was a problem assigning you to the project - please contact the project manager"]);
 

--- a/html/admin/project/project_crew.twig
+++ b/html/admin/project/project_crew.twig
@@ -51,7 +51,7 @@
                                 {% if "PROJECTS:PROJECT_CREW:EDIT"|instancePermissions %}
                                     <i class="far fa-edit editCrewAssignment" data-assignment="{{ crew.crewAssignments_id }}" data-role="{{crew.crewAssignments_role|escape('html_attr')}}" data-comment="{{crew.crewAssignments_comment|escape('html_attr')}}" title="Edit"></i>
                                     <i class="far fa-comment editCrewAssignmentComment" data-assignment="{{ crew.crewAssignments_id }}" data-comment="{{crew.crewAssignments_comment|escape('html_attr')}}" title="Edit comment"></i>
-                                    <i class="fas fa-trash deleteCrewAssignment" data-assignment="{{ crew.crewAssignments_id }}" title="Delete crew"></i>
+                                    <i class="fas fa-trash deleteCrewAssignment" data-assignment="{{ crew.crewAssignments_id }}" data-vacancy="{{ crew.projectsVacantRoles_id }}" title="Delete crew"></i>
                                 {% endif %}
                             </div>
                         </li>

--- a/html/admin/project/project_index.twig
+++ b/html/admin/project/project_index.twig
@@ -1396,6 +1396,7 @@
             });
             $(".deleteCrewAssignment").click(function () {
                 var id = $(this).data("assignment");
+                var hasVacancy = Boolean($(this).data("vacancy"));
                 bootbox.confirm({
                     message: "Are you sure you wish to remove this crew member - they will be notified?",
                     buttons: {
@@ -1410,9 +1411,30 @@
                     },
                     callback: function (result) {
                         if (result) {
-                            ajaxcall("projects/crew/unassign.php", {"crewAssignments_id": id}, function (data) {
-                                location.reload();
-                            });
+                            if (hasVacancy) {
+                                bootbox.confirm({
+                                    message: "Would you like to reopen applications for this crew role?",
+                                    buttons: {
+                                        confirm: {
+                                            label: "Yes",
+                                            className: "btn-success",
+                                        },
+                                        cancel: {
+                                            label: "No",
+                                            className: "btn-default"
+                                        }
+                                    },
+                                    callback: function(reopen) {
+                                        ajaxcall("projects/crew/unassign.php", {"crewAssignments_id": id, "reopenVacancy": reopen}, function (data) {
+                                            location.reload();
+                                        });
+                                    }
+                                });
+                            } else {
+                                ajaxcall("projects/crew/unassign.php", {"crewAssignments_id": id}, function (data) {
+                                    location.reload();
+                                });
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

This PR adds the option to reopen a vacant crew role after removing a crew member. A use case would be when a member informs the PM that they can't make the event, and the PM wants to recruit a replacement.

It does this by tracking the `projectsVacantRoles_id` of the vacancy that the member initially applied through, as this is more reliable than matching by name, If the member was added by name rather than through a vacancy, this does nothing.

It also does not delete the member's `projectsVacantRolesApplications`, so they cannot reapply for the same role - this can be changed if we think it's desirable.

### References

Fixes #523.

### Testing

1. Create a project with a FCFS crew vacancy
2. Sign up for it
3. Remove the signed up crew member - you should see the option to re-open the vacancy.
4. The vacancy should reappear on the Crew Vacancies screen

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`