### PR TITLE
Fix apply / sign up links on mobile

### DIFF
--- a/html/admin/project/crew/vacancies.twig
+++ b/html/admin/project/crew/vacancies.twig
@@ -135,7 +135,13 @@
                                 {% if role.application %}
                                     <button type="button" class="btn btn-default btn-sm" disabled>Applied</button>
                                 {% else %}
-                                    <a type="button" class="btn btn-default btn-sm" href="{{CONFIG.ROOTURL}}/project/crew/vacancy.php?id={{ role.projectsVacantRoles_id }}">Apply</a>
+                                    <a type="button" class="btn btn-default btn-sm" href="{{CONFIG.ROOTURL}}/project/crew/vacancy.php?id={{ role.projectsVacantRoles_id }}">
+                                        {% if role.projectsVacantRoles_firstComeFirstServed %}
+                                        Sign Up
+                                        {% else %}
+                                        Apply
+                                        {% endif %}
+                                    </a>
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

Follow-up to #489 - overlooked the fact that desktop and mobile have separate sections of the template.

### References

#489

### Testing

Create a FCFS vacancy, then open the crew vacancies page on mobile.

### Checklist

- [n/a] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`