### PR TITLE
Add API endpoint to list/search instance users

### DIFF
--- a/html/admin/api/instances/users.php
+++ b/html/admin/api/instances/users.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../apiHeadSecure.php';
 if (!$AUTH->instancePermissionCheck("BUSINESS:USERS:VIEW:LIST")) finish(false, ["code" => "AUTH-ERROR", "message"=> "No auth for action"]);
 
 if (isset($_GET['q'])) $q = $bCMS->sanitizeString($_GET['q']);
-else $q = null;
+else $q = '';
 
 if (isset($_GET['page'])) $page = $bCMS->sanitizeString($_GET['page']);
 else $page = 1;

--- a/html/admin/api/instances/users.php
+++ b/html/admin/api/instances/users.php
@@ -22,28 +22,28 @@ if (strlen($q) > 0) {
 		OR users_name1 LIKE '%" . $bCMS->sanitizeString($q) . "%'
 		OR users_name2 LIKE '%" . $bCMS->sanitizeString($q) . "%'
 		OR users_email LIKE '%" . $bCMS->sanitizeString($q) . "%'
-    )");
+		)");
 }
 $DBLIB->join("userInstances", "users.users_userid=userInstances.users_userid","LEFT");
 $DBLIB->join("instancePositions", "userInstances.instancePositions_id=instancePositions.instancePositions_id","LEFT");
-$DBLIB->where("instances_id",  $AUTH->data['instance']['instances_id']);
-$DBLIB->where("userInstances.userInstances_deleted",  0);
+$DBLIB->where("instances_id", $AUTH->data['instance']['instances_id']);
+$DBLIB->where("userInstances.userInstances_deleted", 0);
 $DBLIB->where("userInstances.userInstances_archived", null, "IS");
 $users = $DBLIB->arraybuilder()->paginate('users', $page, ["users.users_username", "users.users_name1", "users.users_name2", "users.users_userid", "users.users_email", "users.users_emailVerified", "users.users_suspended","users.users_suspended", "instancePositions.instancePositions_displayName", "userInstances.instancePositions_id","users.users_thumbnail"]);
 $return = [];
 foreach ($users as $user) {
-  $return[] = [
-    'users_userid' => $user['users_userid'],
-    'users_username' => $user['users_username'],
-    'users_name1' => $user['users_name1'],
-    'users_name2' => $user['users_name2'],
-    'users_email' => $user['users_email'],
-    'users_emailVerified' => $user['users_emailVerified'] === 1,
-    'users_suspended' => $user['users_suspended'] === 1,
-    'instancePositions_id' => $user['instancePositions_id'],
-    'instancePositions_displayName' => $user['instancePositions_displayName'],
-    'users_thumbnail' => $user['users_thumbnail'],
-  ];
+	$return[] = [
+		'users_userid' => $user['users_userid'],
+		'users_username' => $user['users_username'],
+		'users_name1' => $user['users_name1'],
+		'users_name2' => $user['users_name2'],
+		'users_email' => $user['users_email'],
+		'users_emailVerified' => $user['users_emailVerified'] === 1,
+		'users_suspended' => $user['users_suspended'] === 1,
+		'instancePositions_id' => $user['instancePositions_id'],
+		'instancePositions_displayName' => $user['instancePositions_displayName'],
+		'users_thumbnail' => $user['users_thumbnail'],
+	];
 }
 
 finish(true, null, $return);

--- a/html/admin/api/instances/users.php
+++ b/html/admin/api/instances/users.php
@@ -30,9 +30,9 @@ $DBLIB->where("instances_id", $AUTH->data['instance']['instances_id']);
 $DBLIB->where("userInstances.userInstances_deleted", 0);
 $DBLIB->where("userInstances.userInstances_archived", null, "IS");
 $users = $DBLIB->arraybuilder()->paginate('users', $page, ["users.users_username", "users.users_name1", "users.users_name2", "users.users_userid", "users.users_email", "users.users_emailVerified", "users.users_suspended","users.users_suspended", "instancePositions.instancePositions_displayName", "userInstances.instancePositions_id","users.users_thumbnail"]);
-$return = [];
+$return = ["users" => [], "pagination" => ["thisPageUsers" => count($users), "thisPage" => $page, "totalPages" => $DBLIB->totalPages, "totalUsers" => $DBLIB->totalCount]];
 foreach ($users as $user) {
-	$return[] = [
+	$return["users"][] = [
 		'users_userid' => $user['users_userid'],
 		'users_username' => $user['users_username'],
 		'users_name1' => $user['users_name1'],

--- a/html/admin/api/instances/users.php
+++ b/html/admin/api/instances/users.php
@@ -33,16 +33,16 @@ $users = $DBLIB->arraybuilder()->paginate('users', $page, ["users.users_username
 $return = [];
 foreach ($users as $user) {
   $return[] = [
-    'userid' => $user['users_userid'],
-    'username' => $user['users_username'],
-    'name1' => $user['users_name1'],
-    'name2' => $user['users_name2'],
-    'email' => $user['users_email'],
-    'emailVerified' => $user['users_emailVerified'] === 1,
-    'suspended' => $user['users_suspended'] === 1,
-    'positionId' => $user['instancePositions_id'],
-    'positionDisplayName' => $user['instancePositions_displayName'],
-    'thumbnail' => $user['users_thumbnail'],
+    'users_userid' => $user['users_userid'],
+    'users_username' => $user['users_username'],
+    'users_name1' => $user['users_name1'],
+    'users_name2' => $user['users_name2'],
+    'users_email' => $user['users_email'],
+    'users_emailVerified' => $user['users_emailVerified'] === 1,
+    'users_suspended' => $user['users_suspended'] === 1,
+    'instancePositions_id' => $user['instancePositions_id'],
+    'instancePositions_displayName' => $user['instancePositions_displayName'],
+    'users_thumbnail' => $user['users_thumbnail'],
   ];
 }
 


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

Several API endpoints (for example [`projects/new.php`](https://adam-rms.com/api#tag/projects/operation/new)) take user IDs as parameters, but as far as I can tell (please correct me if I'm wrong!) there's no way for an API user to find the user IDs of an instance's members (as far as I can tell `instances/searchUser.php` explicitly filters out members of the current instance, because it's intended for use by the "add user by email" function).

This PR adds a new API endpoint, `instances/users.php`, that mirrors the existing `instances/users` screen but in API form. It's gated behind `BUSINESS:USERS:VIEW:LIST`.

### Testing

Manually test http://localhost:8080/api/instances/users.php

```json
{
  "result": true,
  "response": [
    {
      "users_userid": 1,
      "users_username": "username",
      "users_name1": "UserF",
      "users_name2": "UserL",
      "users_email": "test@example.com",
      "users_emailVerified": true,
      "users_suspended": false,
      "instancePositions_id": 1,
      "instancePositions_displayName": "Administrator",
      "users_thumbnail": null
    }
  ]
}
```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
  - https://github.com/adam-rms/website/pull/53
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`