### PR TITLE
Improve switching between businesses, and suggest a different business on 404 page

### DIFF
--- a/html/admin/404.twig
+++ b/html/admin/404.twig
@@ -6,11 +6,24 @@
 
         <div class="error-content">
             <h3><i class="fas fa-exclamation-triangle text-warning"></i> Oops! Page not found.</h3>
-
             <p>
                 We could not find the page you were looking for.
-                <br/>Meanwhile, you might want to <a href="{{ CONFIG.ROOTURL }}">return to dashboard</a>, or try checking you are in the right business.
+                <br/>Meanwhile, you might want to <a href="{{ CONFIG.ROOTURL }}">return to dashboard</a>{% if USERDATA.instances|length > 1 %}, or try changing to a different business:{% endif %}
             </p>
+            {% if USERDATA.instances|length > 1 %}
+            <ul>
+                {% for instance in USERDATA.instances %}
+                    {% if USERDATA.instance.instances_id != instance.instances_id %}
+                        <li>
+                            <a href="{{ CONFIG.ROOTURL }}?i={{instance.instances_id}}"  class="changeInstanceActionButton" data-newinstance="{{instance.instances_id}}">
+                                {{instance.instances_name}}
+                            </a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
+            {% endif  %}
         </div>
     </div>
+    
 {% endblock %}

--- a/html/admin/api/projects/data.php
+++ b/html/admin/api/projects/data.php
@@ -25,7 +25,7 @@ $DBLIB->join("users", "projects.projects_manager=users.users_userid", "LEFT");
 $DBLIB->join("locations","locations.locations_id=projects.locations_id","LEFT");
 $DBLIB->join("projectsStatuses", "projects.projectsStatuses_id=projectsStatuses.projectsStatuses_id", "LEFT");
 $PAGEDATA['project'] = $DBLIB->getone("projects", ["projects.*", "projectsTypes.*", "clients.clients_id", "clients_name","clients_website","clients_email","clients_notes","clients_address","clients_phone","users.users_userid", "users.users_name1", "users.users_name2", "users.users_email","locations.locations_name","locations.locations_address","projectsStatuses.projectsStatuses_id", "projectsStatuses.projectsStatuses_name", "projectsStatuses.projectsStatuses_foregroundColour","projectsStatuses.projectsStatuses_backgroundColour","projectsStatuses.projectsStatuses_assetsReleased","projectsStatuses.projectsStatuses_description"]);
-if (!$PAGEDATA['project']) die("404");
+if (!$PAGEDATA['project']) $PAGEDATA['USE_TWIG_404'] ? die($TWIG->render('404.twig', $PAGEDATA)) : die("404");
 
 //subprojects
 $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);

--- a/html/admin/assets/template.twig
+++ b/html/admin/assets/template.twig
@@ -274,7 +274,7 @@
                         {% if USERDATA.instances|length > 1 %}
                             <span class="dropdown-header">Your Businesses</span>
                             {% for instance in USERDATA.instances %}
-                                <a href="{{ CONFIG.ROOTURL }}?i={{instance.instances_id}}" class="dropdown-item">
+                                <a href="{{ CONFIG.ROOTURL }}?i={{instance.instances_id}}" class="dropdown-item changeInstanceActionButton" data-newinstance="{{instance.instances_id}}">
                                     {{instance.instances_name}}
                                     <p class="text-sm text-muted">{{ instance.userInstances_label }}</p>
                                     {% if USERDATA.instance.instances_id == instance.instances_id %}
@@ -933,7 +933,14 @@
             });
         });
         {% endif %}
-
+        {% if USERDATA.instances|length > 1 %}
+            $(".changeInstanceActionButton[data-newinstance]").click(function (event) {
+                event.preventDefault();
+                ajaxcall("instances/switch.php", {'instances_id': $(this).data("newinstance")}, function (data) {
+                    location.reload();
+                });
+            });
+        {% endif %}
     });
     console.log("Welcome to {{ CONFIG.PROJECT_NAME|escape("js") }} version {{ (CONFIG.VERSION.ENV ?: CONFIG.VERSION.TAG)|escape("js") }}");
 </script>

--- a/html/admin/maintenance/job.php
+++ b/html/admin/maintenance/job.php
@@ -13,7 +13,7 @@ $DBLIB->where("maintenanceJobs.maintenanceJobs_id", $_GET['id']);
 $DBLIB->join("users AS userCreator", "userCreator.users_userid=maintenanceJobs.maintenanceJobs_user_creator", "LEFT");
 $DBLIB->join("users AS userAssigned", "userAssigned.users_userid=maintenanceJobs.maintenanceJobs_user_assignedTo", "LEFT");
 $PAGEDATA['job'] = $DBLIB->getone("maintenanceJobs", ["maintenanceJobs.*", "userCreator.users_userid AS userCreatorUserID", "userCreator.users_name1 AS userCreatorUserName1", "userCreator.users_name2 AS userCreatorUserName2", "userCreator.users_email AS userCreatorUserEMail","userAssigned.users_name1 AS userAssignedUserName1","userAssigned.users_userid AS userAssignedUserID", "userAssigned.users_name2 AS userAssignedUserName2", "userAssigned.users_email AS userAssignedUserEMail"]);
-if (!$PAGEDATA['job']) die("404");
+if (!$PAGEDATA['job']) die($TWIG->render('404.twig', $PAGEDATA));
 
 // Statuses
 $DBLIB->where("maintenanceJobsStatuses_deleted", 0);

--- a/html/admin/project/crew/vacantCrew.php
+++ b/html/admin/project/crew/vacantCrew.php
@@ -9,7 +9,7 @@ $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
 $DBLIB->where("projects.projects_deleted", 0);
 $DBLIB->where("projects.projects_id", $_GET['id']);
 $PAGEDATA['project'] = $DBLIB->getone("projects", ["projects.*"]);
-if (!$PAGEDATA['project']) die("404");
+if (!$PAGEDATA['project']) die($TWIG->render('404.twig', $PAGEDATA));
 
 $DBLIB->where("projectsVacantRoles_deleted",0);
 $DBLIB->where("projects_id",$PAGEDATA['project']['projects_id']);

--- a/html/admin/project/index.php
+++ b/html/admin/project/index.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../common/headSecure.php';
 if (!$AUTH->instancePermissionCheck("PROJECTS:VIEW") or !isset($_GET['id'])) die($TWIG->render('404.twig', $PAGEDATA));
+$PAGEDATA['USE_TWIG_404'] = true;
 require_once __DIR__ . '/../api/projects/data.php'; //Where most of the data comes from
 
 //AuditLog

--- a/html/admin/project/noteExport.php
+++ b/html/admin/project/noteExport.php
@@ -11,7 +11,7 @@ $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
 $DBLIB->where("projects.projects_deleted", 0);
 $DBLIB->where("projects.projects_id", $PAGEDATA['note']['projects_id']);
 $PAGEDATA['project'] = $DBLIB->getone("projects", ["projects.*"]);
-if (!$PAGEDATA['project']) die("404");
+if (!$PAGEDATA['project']) die($TWIG->render('404.twig', $PAGEDATA));
 
 echo $TWIG->render('project/export-note.twig', $PAGEDATA);
 ?>


### PR DESCRIPTION
@Robert-Watts spotted that the 404 page doesn't display if you follow a project link in a different instance. This PR puts the correct 404 page in, and improves both the 404 page and top menu instance switching functionality by not redirecting back to the dashboard (albeit at risk of a 404 occuring if you click the instance switcher whilst in a project for example).

What do people think of this change?