### PR TITLE
Allow deleted tags to be used by other assets

### DIFF
--- a/html/admin/api/assets/editAsset.php
+++ b/html/admin/api/assets/editAsset.php
@@ -32,6 +32,7 @@ $asset = $DBLIB->getone("assets", ['assets.assets_dayRate','assets.assets_tag','
 if (isset($array['assets_tag']) and $array['assets_tag'] != $asset['assets_tag']) {
     $DBLIB->where("assets.instances_id",$AUTH->data['instance']['instances_id']);
     $DBLIB->where("assets.assets_tag", $array['assets_tag']);
+    $DBLIB->where("assets.assets_deleted", 0); //Deleted assets can't be restored, so can be used
     $duplicateAssetTag = $DBLIB->getValue ("assets", "count(*)");
     if ($duplicateAssetTag > 0) finish(false,["message" => "Sorry that Asset Tag is a duplicate of one already in your Business"]);
 }

--- a/html/admin/api/assets/newAssetFromType.php
+++ b/html/admin/api/assets/newAssetFromType.php
@@ -19,6 +19,7 @@ if (!$asset) finish(false, ["code" => "LIST-ASSETTYPES-FAIL", "message"=> "Could
 if (isset($array['assets_tag']) and $array['assets_tag'] != null) {
     $DBLIB->where("assets.instances_id",$AUTH->data['instance']['instances_id']);
     $DBLIB->where("assets.assets_tag", $array['assets_tag']);
+    $DBLIB->where("assets.assets_deleted", 0); //Deleted assets can't be restored, so can be used
     $duplicateAssetTag = $DBLIB->getValue ("assets", "count(*)");
     if ($duplicateAssetTag > 0) finish(false, ["code" => "INSERT-FAIL", "message"=> "Sorry that tag you chose was a duplicate - please choose another one"]);
 } else $array['assets_tag'] = generateNewTag();


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description
Allows asset tags that are used by a deleted asset to be used by another asset


### References
Closes #505 


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`