### PR TITLE
Remove Image Compression

### DIFF
--- a/db/migrations/20240105170000_remove_image_compression.php
+++ b/db/migrations/20240105170000_remove_image_compression.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class DropProjectStatusClass extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $table = $this->table('s3files');
+        $table->removeColumn('s3files_compressed')
+              ->save();
+    }
+}

--- a/html/admin/api/assets/list.php
+++ b/html/admin/api/assets/list.php
@@ -31,7 +31,7 @@ $PAGEDATA['assets'] = [];
 foreach ($assets as $asset) {
     $asset['thumbnails'] = [];
     foreach ($bCMS->s3List(2, $asset['assetTypes_id']) as $thumbnail) {
-        $thumbnail['url'] = $bCMS->s3URL($thumbnail['s3files_id'], ($_POST['imageComp'] ? $_POST['imageComp'] : false), false, '+1 hour');
+        $thumbnail['url'] = $bCMS->s3URL($thumbnail['s3files_id'], false, '+1 hour');
         $asset['thumbnails'][] = $thumbnail;
     }
 

--- a/html/admin/api/file/index.php
+++ b/html/admin/api/file/index.php
@@ -4,12 +4,11 @@ require_once __DIR__ . '/../apiHead.php';
  * File interface for Amazon AWS S3.
  *  Parameters
  *      f (required) - the file id as specified in the database
- *      s (filesize) - false to get the original - available is "tiny" (50px) "small" (100px) "medium" (500px) "large" (1000px)
  *      d (optional, default false) - should a download be forced or should it be displayed in the browser? (if set it will download)
  *      r (optional, default false) - should the url be returned by the script as plain text or a redirect triggered? (if set it will redirect)
  *      e (optional, default 1 minute) - when should the link expire? Must be a string describing how long in words basically. If this file type has security features then it will default to 1 minute.
  */
-$file = $bCMS->s3URL($_POST['f'], (isset($_POST['s']) ? $_POST['s'] : null), (isset($_POST['d'])),(isset($_POST['e']) ? $_POST['e'] : null),(isset($_POST['key']) ? $_POST['key'] : null));
+$file = $bCMS->s3URL($_POST['f'], (isset($_POST['d'])),(isset($_POST['e']) ? $_POST['e'] : null),(isset($_POST['key']) ? $_POST['key'] : null));
 if (!$file) finish(false,["message"=>"File not found - please check to ensure you are still logged in"]);
 else {
     if (isset($_POST['r'])) {

--- a/html/admin/asset.twig
+++ b/html/admin/asset.twig
@@ -74,7 +74,8 @@
                             <div>
                                 <img class="img-fluid" style="max-height: 340px;"
                                      src="{{ thumb.s3files_id|s3URL("small") }}"
-                                     alt="{{asset.assetTypes_name}}">
+                                     alt="{{asset.assetTypes_name}}"
+                                     loading="lazy">
                             </div>
                         {% endfor %}
                     </div>
@@ -611,7 +612,7 @@
                                                                     <ul class="list-inline">
                                                                         <li class="list-inline-item">
                                                                             <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userCreatorUserID }}" title="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 ~ " (" ~ job.userCreatorUserEMail ~ ")" }}">
-                                                                                <img alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                                                                <img loading="lazy" alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                                                             </a>
                                                                         </li>
                                                                     </ul>
@@ -621,7 +622,7 @@
                                                                         <ul class="list-inline">
                                                                             <li class="list-inline-item">
                                                                                 <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userAssignedUserID }}" title="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 ~ " (" ~ job.userAssignedUserEMail ~ ")" }}">
-                                                                                    <img alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                                                                    <img loading="lazy" alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                                                                 </a>
                                                                             </li>
                                                                         </ul>
@@ -707,7 +708,7 @@
                                                                     <ul class="list-inline">
                                                                         <li class="list-inline-item">
                                                                             <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userCreatorUserID }}" title="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 ~ " (" ~ job.userCreatorUserEMail ~ ")" }}">
-                                                                                <img alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                                                                <img loading="lazy" alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                                                             </a>
                                                                         </li>
                                                                     </ul>
@@ -717,7 +718,7 @@
                                                                         <ul class="list-inline">
                                                                             <li class="list-inline-item">
                                                                                 <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userAssignedUserID }}" title="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 ~ " (" ~ job.userAssignedUserEMail ~ ")" }}">
-                                                                                    <img alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                                                                    <img loading="lazy" alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                                                                 </a>
                                                                             </li>
                                                                         </ul>
@@ -1178,7 +1179,7 @@
                                                                 <ul class="list-inline">
                                                                     <li class="list-inline-item">
                                                                         <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userCreatorUserID }}" title="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 ~ " (" ~ job.userCreatorUserEMail ~ ")" }}">
-                                                                            <img alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                                                            <img loading="lazy" alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                                                         </a>
                                                                     </li>
                                                                 </ul>
@@ -1188,7 +1189,7 @@
                                                                     <ul class="list-inline">
                                                                         <li class="list-inline-item">
                                                                             <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userAssignedUserID }}" title="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 ~ " (" ~ job.userAssignedUserEMail ~ ")" }}">
-                                                                                <img alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                                                                <img loading="lazy" alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                                                             </a>
                                                                         </li>
                                                                     </ul>
@@ -1274,7 +1275,7 @@
                                                                     <ul class="list-inline">
                                                                         <li class="list-inline-item">
                                                                             <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userCreatorUserID }}" title="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 ~ " (" ~ job.userCreatorUserEMail ~ ")" }}">
-                                                                                <img alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                                                                <img loading="lazy" alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                                                             </a>
                                                                         </li>
                                                                     </ul>
@@ -1284,7 +1285,7 @@
                                                                         <ul class="list-inline">
                                                                             <li class="list-inline-item">
                                                                                 <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userAssignedUserID }}" title="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 ~ " (" ~ job.userAssignedUserEMail ~ ")" }}">
-                                                                                    <img alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                                                                    <img loading="lazy" alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                                                                 </a>
                                                                             </li>
                                                                         </ul>

--- a/html/admin/assets.twig
+++ b/html/admin/assets.twig
@@ -192,7 +192,7 @@
                                                     <a href="{{ CONFIG.ROOTURL }}/asset.php?id={{ asset.assetTypes_id }}{{ asset.count == 1 ? '&asset=' ~ asset.tags[0]['assets_id'] : '' }}{{ SEARCH["SETTINGS"]["SHOWARCHIVED"] ? '&showArchived' : ''}}&instance={{ searchResults.SEARCH.INSTANCE_ID }}" target="_blank">
                                                     <img class="img-fluid" loading="lazy" style="max-height: 200px;"
                                                         src="{{ thumb.s3files_id|s3URL("small") }}"
-                                                        alt="{{asset.assetTypes_name}}"></a>
+                                                        fetchpriority="low" alt="{{asset.assetTypes_name}}"></a>
                                                 </div>
                                             {% endfor %}
                                         </div>

--- a/html/admin/assets/template.twig
+++ b/html/admin/assets/template.twig
@@ -327,7 +327,7 @@
             <!-- Sidebar user (optional) -->
             <div class="user-panel mt-3 pb-3 mb-3 d-flex">
                 <div class="image">
-                    <img src="{{ USERDATA.users_thumbnail ? USERDATA.users_thumbnail|s3URL("tiny") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}" class="img-circle elevation-2" alt="User Image" style="background-color: white;"  loading="lazy">
+                    <img src="{{ USERDATA.users_thumbnail ? USERDATA.users_thumbnail|s3URL("tiny") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}" class="img-circle elevation-2" alt="User Image" style="background-color: white;"  loading="lazy" fetchpriority="high">
                 </div>
                 <a href="{{ CONFIG.ROOTURL }}/user.php" class="d-block">
                 <div class="info">

--- a/html/admin/instances/instances_settings.twig
+++ b/html/admin/instances/instances_settings.twig
@@ -270,7 +270,7 @@
             </div>
             <div class="card-body">
                 {% if USERDATA.instance.instances_logo != null %}
-                    <img src="{{ USERDATA.instance.instances_logo|s3URL("medium") }}" style="width: 100%;">
+                    <img loading="lazy" src="{{ USERDATA.instance.instances_logo|s3URL("medium") }}" style="width: 100%;">
                 {% else %}
                     <i>None currently set</i>
                 {% endif %}
@@ -296,7 +296,7 @@
             </div>
             <div class="card-body">
                 {% if USERDATA.instance.instances_emailHeader != null %}
-                    <img src="{{ USERDATA.instance.instances_emailHeader|s3URL("medium") }}" style="width: 100%;">
+                    <img loading="lazy" src="{{ USERDATA.instance.instances_emailHeader|s3URL("medium") }}" style="width: 100%;">
                 {% else %}
                     <i>None currently set</i>
                 {% endif %}

--- a/html/admin/instances/instances_users.twig
+++ b/html/admin/instances/instances_users.twig
@@ -52,7 +52,7 @@
                                         {% endif %}>
                                     <td>
                                         {% if user.users_thumbnail %}
-                                            <img alt="{{user.users_name1 ~ " " ~ user.users_name2 }}" class="table-avatar" style="height: 63px;" src="{{ user.users_thumbnail ? user.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                            <img loading="lazy" alt="{{user.users_name1 ~ " " ~ user.users_name2 }}" class="table-avatar" style="height: 63px;" src="{{ user.users_thumbnail ? user.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                         {% endif %}
                                     </td>
                                     <td>

--- a/html/admin/maintenance/job.twig
+++ b/html/admin/maintenance/job.twig
@@ -271,21 +271,21 @@
                                 <span class="direct-chat-name float-left">{{ message.users_name1 ~ " " ~ message.users_name2 }}</span>
                                 <span class="direct-chat-timestamp float-right">{{ message.maintenanceJobsMessages_timestamp|date("d M Y h:ia") }}</span>
                             </div>
-                            <img class="direct-chat-img" src="{{ message.users_thumbnail ? message.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}"  alt="{{ message.users_name1 ~ " " ~ message.users_name2 }}">
+                            <img loading="lazy" class="direct-chat-img" src="{{ message.users_thumbnail ? message.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}"  alt="{{ message.users_name1 ~ " " ~ message.users_name2 }}">
                         {% else %}
                         <div class="direct-chat-msg right">
                             <div class="direct-chat-infos clearfix">
                                 <span class="direct-chat-name float-right">{{ message.users_name1 ~ " " ~ message.users_name2 }}</span>
                                 <span class="direct-chat-timestamp float-left">{{ message.maintenanceJobsMessages_timestamp|date("d M Y h:ia") }}</span>
                             </div>
-                            <img class="direct-chat-img" src="{{ message.users_thumbnail ? message.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}"  alt="{{ message.users_name1 ~ " " ~ message.users_name2 }}">
+                            <img loading="lazy" class="direct-chat-img" src="{{ message.users_thumbnail ? message.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}"  alt="{{ message.users_name1 ~ " " ~ message.users_name2 }}">
                         {% endif %}
                             <div class="direct-chat-text">
                                 {% if message.maintenanceJobsMessages_text|length > 0 %}
                                     {{ message.maintenanceJobsMessages_text|nl2br }}
                                 {% elseif message.maintenanceJobsMessages_file != "" %}
                                     {% if message.s3files_extension|lower in ["gif", "jpeg", "jpg", "png"] %}
-                                        <img src="{{ message.maintenanceJobsMessages_file|s3URL("medium") }}" alt="{{ message.s3files_name }}" style="width: 100%;">
+                                        <img loading="lazy" src="{{ message.maintenanceJobsMessages_file|s3URL("medium") }}" alt="{{ message.s3files_name }}" style="width: 100%;">
                                     {% else %}
                                         <a href="{{ message.maintenanceJobsMessages_file|s3URL }}" target="_blank" style="color:white;"><i class="fa {{ message.s3files_extension|fontAwesomeFile }}"></i> {{ message.s3files_name }}</a>
                                     {% endif %}

--- a/html/admin/maintenance/maintenance_index.twig
+++ b/html/admin/maintenance/maintenance_index.twig
@@ -70,7 +70,7 @@
                     <ul class="list-inline">
                         <li class="list-inline-item">
                             <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userCreatorUserID }}" title="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 ~ " (" ~ job.userCreatorUserEMail ~ ")" }}">
-                                <img alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                <img loading="lazy" alt="{{job.userCreatorUserName1 ~ " " ~ job.userCreatorUserName2 }}" class="table-avatar" src="{{ job.userCreatorUserThumb ? job.userCreatorUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                             </a>
                         </li>
                     </ul>
@@ -80,7 +80,7 @@
                         <ul class="list-inline">
                             <li class="list-inline-item">
                                 <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ job.userAssignedUserID }}" title="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 ~ " (" ~ job.userAssignedUserEMail ~ ")" }}">
-                                    <img alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                    <img loading="lazy" alt="{{job.userAssignedUserName1 ~ " " ~ job.userAssignedUserName2 }}" class="table-avatar" src="{{ job.userAssignedUserThumb ? job.userAssignedUserThumb|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                 </a>
                             </li>
                         </ul>

--- a/html/admin/project/projectInvoice.php
+++ b/html/admin/project/projectInvoice.php
@@ -21,7 +21,7 @@ else $fileNumber = 1;
 $PAGEDATA['fileNumber'] = $fileNumber;
 
 if ($PAGEDATA['USERDATA']['instance']['instances_logo'] and $PAGEDATA['GET']['instancelogo']) {
-    $PAGEDATA['INSTANCELOGO'] = $bCMS->s3DataUri($PAGEDATA['USERDATA']['instance']['instances_logo'], "medium");
+    $PAGEDATA['INSTANCELOGO'] = $bCMS->s3DataUri($PAGEDATA['USERDATA']['instance']['instances_logo']);
 } else $PAGEDATA['INSTANCELOGO'] = false;
 
 echo $TWIG->render('project/pdf.twig', $PAGEDATA);

--- a/html/admin/project/project_list.twig
+++ b/html/admin/project/project_list.twig
@@ -91,7 +91,7 @@
                             <ul class="list-inline">
                                 <li class="list-inline-item">
                                     <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ project.projects_manager }}" title="{{project.users_name1 ~ " " ~ project.users_name2 ~ " (" ~ project.users_email ~ ")" }}">
-                                        <img alt="{{ project.users_name1 ~ " " ~ project.users_name2 }}" class="table-avatar" src="{{ project.users_thumbnail ? project.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                        <img loading="lazy" alt="{{ project.users_name1 ~ " " ~ project.users_name2 }}" class="table-avatar" src="{{ project.users_thumbnail ? project.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                     </a>
                                 </li>
                             </ul>
@@ -147,7 +147,7 @@
                                     <ul class="list-inline">
                                         <li class="list-inline-item">
                                             <a href="{{ CONFIG.ROOTURL }}/user.php?id={{ subProject.projects_manager }}" title="{{subProject.users_name1 ~ " " ~ subProject.users_name2 ~ " (" ~ subProject.users_email ~ ")" }}">
-                                                <img alt="{{ subProject.users_name1 ~ " " ~ subProject.users_name2 }}" class="table-avatar" src="{{ subProject.users_thumbnail ? subProject.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
+                                                <img loading="lazy" alt="{{ subProject.users_name1 ~ " " ~ subProject.users_name2 }}" class="table-avatar" src="{{ subProject.users_thumbnail ? subProject.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}">
                                             </a>
                                         </li>
                                     </ul>

--- a/html/admin/support.twig
+++ b/html/admin/support.twig
@@ -54,7 +54,7 @@
                                             <div class="card">
                                                 <div class="card-footer card-comments">
                                                     <div class="card-comment">
-                                                        <img class="img-circle img-sm" src="{{ USERDATA.users_thumbnail ? USERDATA.users_thumbnail|s3URL("tiny") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}" alt="User Image">
+                                                        <img class="img-circle img-sm" loading="lazy" src="{{ USERDATA.users_thumbnail ? USERDATA.users_thumbnail|s3URL("tiny") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}" alt="User Image">
                                                         <div class="comment-text">
                                                             <span class="username">
                                                                 {{ USERDATA.users_name1 }} {{ USERDATA.users_name2 }}
@@ -67,7 +67,7 @@
                                                         {% if message.private == false %}
                                                             {% if message.incoming %}
                                                                 <div class="card-comment">
-                                                                    <img class="img-circle img-sm" src="{{ USERDATA.users_thumbnail ? USERDATA.users_thumbnail|s3URL("tiny") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}" alt="User Image">
+                                                                    <img class="img-circle img-sm" loading="lazy" src="{{ USERDATA.users_thumbnail ? USERDATA.users_thumbnail|s3URL("tiny") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}" alt="User Image">
                                                                     <div class="comment-text">
                                                                         <span class="username">
                                                                             {{ USERDATA.users_name1 }} {{ USERDATA.users_name2 }}

--- a/html/admin/training/training_modules.twig
+++ b/html/admin/training/training_modules.twig
@@ -66,7 +66,7 @@
                            <div>
                                {% if module.modules_type != 3 %}<a href="{{ CONFIG.ROOTURL }}/training/module.php?id={{ module.modules_id }}">{% else %}<a href="#">{% endif %}
                                     <img class="img-fluid" style="max-height: 340px;"
-                                         src="{{ module.modules_thumbnail|s3URL("small") }}"
+                                         loading="lazy" src="{{ module.modules_thumbnail|s3URL("small") }}"
                                          alt="{{ module.modules_name }}"></a>
                             </div>
                             <br/>

--- a/html/admin/user.twig
+++ b/html/admin/user.twig
@@ -15,6 +15,7 @@
                         <div class="text-center">
                             <img class="profile-user-img img-fluid img-circle"
                                  src="{{ user.users_thumbnail ? user.users_thumbnail|s3URL("small") : CONFIG.ROOTURL ~ '/static-assets/img/default-profile-picture.jpg' }}"
+                                 loading="lazy"
                                  alt="{{ user.users_name1 }} {{ user.users_name2 }}">
                         </div>
                     <h3 class="profile-username text-center">{{ user.users_name1 }} {{ user.users_name2 }}</h3>
@@ -225,7 +226,7 @@
                             </div>
                             <div class="tab-pane table-responsive p-3" id="profilepicture">
                                 {% if user.users_thumbnail != null %}
-                                    <img src="{{ user.users_thumbnail|s3URL("small") }}" style="max-width: 100%; min-width: 150px; max-height: 400px;margin-bottom: 15px;" />
+                                    <img loading="lazy" src="{{ user.users_thumbnail|s3URL("small") }}" style="max-width: 100%; min-width: 150px; max-height: 400px;margin-bottom: 15px;" />
                                 {% endif %}
                                 {% if "USERS:EDIT:THUMBNAIL"|serverPermissions or user.users_userid == USERDATA.users_userid %}
                                     {% embed 'common/plugins/uppy.twig' with {'type': 'USER-THUMBNAIL', 'paste': false, 'typeId': 9, 'subTypeId': USER.users_userid, 'fileLimit': 1, 'imagesOnly': true } %}

--- a/html/common/coreHead.php
+++ b/html/common/coreHead.php
@@ -169,11 +169,8 @@ class bCMS {
 
         $instanceIgnore = false;
         $secure = true;
+        // This list is also used to populate the files deletion suggestor
         switch ($file['s3files_meta_type']) {
-            case 1:
-                $instanceIgnore = true;
-                //This is a user thumbnail
-                break;
             case 2:
                 $instanceIgnore = true;
                 $secure = false; //Needs to be viewed on the public site

--- a/html/common/coreHead.php
+++ b/html/common/coreHead.php
@@ -187,9 +187,6 @@ class bCMS {
                 $secure = false;
                 // Instance thumbnail
                 break;
-            case 6:
-                // Instance file
-                break;
             case 7:
                 //Project file
                 break;

--- a/html/common/libs/twig.php
+++ b/html/common/libs/twig.php
@@ -68,9 +68,9 @@ $TWIG->addFilter(new \Twig\TwigFilter('randomString', function ($characters) {
     global $bCMS;
     return $bCMS->randomString($characters);
 }));
-$TWIG->addFilter(new \Twig\TwigFilter('s3URL', function ($fileid, $size = false) {
+$TWIG->addFilter(new \Twig\TwigFilter('s3URL', function ($fileid) {
     global $CONFIG;
-    return $CONFIG['ROOTURL'] . "/api/file/index.php?r&f=" . $fileid . "&s=" . $size;
+    return $CONFIG['ROOTURL'] . "/api/file/index.php?r&f=" . $fileid;
 }));
 $TWIG->addFilter(new \Twig\TwigFilter('jsonDecode', function ($raw) {
     if ($raw == null) return [];

--- a/html/common/libs/twig.php
+++ b/html/common/libs/twig.php
@@ -68,8 +68,9 @@ $TWIG->addFilter(new \Twig\TwigFilter('randomString', function ($characters) {
     global $bCMS;
     return $bCMS->randomString($characters);
 }));
-$TWIG->addFilter(new \Twig\TwigFilter('s3URL', function ($fileid) {
+$TWIG->addFilter(new \Twig\TwigFilter('s3URL', function ($fileid, $size = null) {
     global $CONFIG;
+    // The size parameter is no longer used, but is kept incase it is used in the future.
     return $CONFIG['ROOTURL'] . "/api/file/index.php?r&f=" . $fileid;
 }));
 $TWIG->addFilter(new \Twig\TwigFilter('jsonDecode', function ($raw) {


### PR DESCRIPTION
Currently, AdamRMS stores the originally uploaded image for user attachments, and as an offline process then compresses that image into a number of different sizes - this improves frontend web performance.

That said, this increases costs, as more files are stored than are needed, and makes self-hosting harder as you need a seperate script and infastructure to compress images.

This PR removes the image compression functionality, but adds browser signals to encourage lazy loading of images which aids performance