### PR TITLE
Move database library reference to own repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,14 @@
 {
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/adam-rms/php-mysqli-database-class"
+    }
+  ],
   "require": {
+    "adam-rms/mysqli-database-class": "dev-main",
     "twig/twig": "v3.7.*",
     "ezyang/htmlpurifier": "v4.17.*",
-    "joshcam/mysqli-database-class": "dev-master",
     "sendgrid/sendgrid": "v8.1.*",
     "phpoffice/phpspreadsheet": "1.29.*",
     "ext-zip": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,56 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ec9c4f09373557f16b556f96ac8b1c6",
+    "content-hash": "0ed1d57807a90c6b47e0d4dde3706370",
     "packages": [
+        {
+            "name": "adam-rms/mysqli-database-class",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/adam-rms/PHP-MySQLi-Database-Class.git",
+                "reference": "adee869ec2a333a868fe1ca026ebd9dfd5856f4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/adam-rms/PHP-MySQLi-Database-Class/zipball/adee869ec2a333a868fe1ca026ebd9dfd5856f4e",
+                "reference": "adee869ec2a333a868fe1ca026ebd9dfd5856f4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "MysqliDb.php",
+                    "dbObject.php"
+                ]
+            },
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Josh Campbell",
+                    "email": "josh.lee.campbell@gmail.com",
+                    "homepage": "https://github.com/thingengineer",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Alexander V. Butenko",
+                    "email": "a.butenka@gmail.com",
+                    "homepage": "http://smarttechdo.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP MySQL Wrapper and object mapper which utilizes MySQLi and prepared statements",
+            "support": {
+                "source": "https://github.com/adam-rms/PHP-MySQLi-Database-Class/tree/main"
+            },
+            "time": "2024-01-13T14:49:38+00:00"
+        },
         {
             "name": "aws/aws-crt-php",
             "version": "v1.2.4",
@@ -62,16 +110,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.295.10",
+            "version": "3.296.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "4d8b4f47639275248e212bd61b6bc51f9dd709f2"
+                "reference": "7c61ea4f7df51e6e9f1e7fc1112e296bed8429f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4d8b4f47639275248e212bd61b6bc51f9dd709f2",
-                "reference": "4d8b4f47639275248e212bd61b6bc51f9dd709f2",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/7c61ea4f7df51e6e9f1e7fc1112e296bed8429f9",
+                "reference": "7c61ea4f7df51e6e9f1e7fc1112e296bed8429f9",
                 "shasum": ""
             },
             "require": {
@@ -151,9 +199,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.295.10"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.296.0"
             },
-            "time": "2024-01-11T19:04:31+00:00"
+            "time": "2024-01-12T19:32:12+00:00"
         },
         {
             "name": "cakephp/core",
@@ -1130,56 +1178,6 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.5"
             },
             "time": "2021-10-08T21:21:46+00:00"
-        },
-        {
-            "name": "joshcam/mysqli-database-class",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ThingEngineer/PHP-MySQLi-Database-Class.git",
-                "reference": "5159467ae081adbe96586e45e65a58c0fe7a32ce"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ThingEngineer/PHP-MySQLi-Database-Class/zipball/5159467ae081adbe96586e45e65a58c0fe7a32ce",
-                "reference": "5159467ae081adbe96586e45e65a58c0fe7a32ce",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "default-branch": true,
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "MysqliDb.php",
-                    "dbObject.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Josh Campbell",
-                    "email": "josh.lee.campbell@gmail.com",
-                    "homepage": "https://github.com/thingengineer",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Alexander V. Butenko",
-                    "email": "a.butenka@gmail.com",
-                    "homepage": "http://smarttechdo.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "PHP MySQL Wrapper and object mapper which utilizes MySQLi and prepared statements",
-            "support": {
-                "issues": "https://github.com/ThingEngineer/PHP-MySQLi-Database-Class/issues",
-                "source": "https://github.com/ThingEngineer/PHP-MySQLi-Database-Class/tree/master"
-            },
-            "time": "2022-09-13T15:42:11+00:00"
         },
         {
             "name": "loilo/fuse",
@@ -4423,7 +4421,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "joshcam/mysqli-database-class": 20
+        "adam-rms/mysqli-database-class": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
Self host the database library on Github in our own repo (https://github.com/adam-rms/PHP-MySQLi-Database-Class) to be able to lock-into a version, to try and tackle risk of supply chain attack.