### PR TITLE
Check for Google Auth config before allowing google auth

### DIFF
--- a/html/admin/login/index.php
+++ b/html/admin/login/index.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../common/head.php';
 use \Firebase\JWT\JWT;
 
 $PAGEDATA['pageConfig'] = ["TITLE" => "Login"];
+$PAGEDATA['googleAuthAvailable'] = $CONFIG['AUTH-PROVIDERS']['GOOGLE']['keys']['id'] != "" and $CONFIG['AUTH-PROVIDERS']['GOOGLE']['keys']['secret'] != "";
 
 if (isset($_GET['app-oauth'])) {
 	$_SESSION['return'] = false;
@@ -36,6 +37,11 @@ elseif (isset($_GET['app-magiclink']) and (in_array($_GET['app-magiclink'], $GLO
 	$PAGEDATA['MAGICLINKURL'] = $_GET['app-magiclink'];
 	echo $TWIG->render('login/magicLink.twig', $PAGEDATA);
 } elseif (isset($_GET['google'])) {
+	if (!$PAGEDATA['googleAuthAvailable']) {
+		//Display normal login page if Google isn't available
+		echo $TWIG->render('login/login_index.twig', $PAGEDATA);
+		exit;
+	}
 	//Similar setup can be found in the link provider api endpoint
 	$CONFIG['AUTH-PROVIDERS']['GOOGLE']['callback'] = $CONFIG['ROOTURL'] . '/login/index.php?google';
 

--- a/html/admin/login/login_index.twig
+++ b/html/admin/login/login_index.twig
@@ -3,7 +3,9 @@
     <div id="browser">
 
     </div>
+    {% if googleAuthAvailable %}
     <a href="?google"><img src="{{ CONFIG.ROOTURL}}/static-assets/img/loginButtons/continueWithGoogle.png" alt="Login with Google" /></a><br/>
+    {% endif %}
     <a href="?login"><img src="{{ CONFIG.ROOTURL}}/static-assets/img/loginButtons/continueWithAdamrms.png" alt="Login with AdamRMS"  style="width: 220px;" /></a>
     
 	<script>


### PR DESCRIPTION
### Description

Checks for the presence of bCMS__OAUTH__GOOGLEKEY and bCMS__OAUTH__GOOGLESECRET before showing 'Log in with google' or trying to do the google auth flow

![Login without google](https://github.com/adam-rms/adam-rms/assets/54247748/7bae9344-13ee-47fe-99b3-43401ab004da)

Closes #597 

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [x] I have updated the API documentation for any routes changed, within each api file.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue is linked to this pull request.
