### PR TITLE
Bring public crew recruitment up to date with internal page

### DIFF
--- a/html/admin/instances/instances_public.twig
+++ b/html/admin/instances/instances_public.twig
@@ -18,9 +18,13 @@
                         <label class="form-check-label">Enabled</label>
                     </div>
                     <hr/>
-                    <div class="form-check">
+                    <div class="form-check py-1">
                         <input type="checkbox" class="form-check-input" name="enableVacancies" {{ publicData.enableVacancies ? 'checked' : '' }}>
                         <label class="form-check-label">Enable Crew Vacancies</label>
+                    </div>
+                    <div class="form-check py-1">
+                        <input type="checkbox" class="form-check-input" name="showVacancyClients" {{ publicData.showVacancyClients ? 'checked' : '' }}>
+                        <label class="form-check-label">Show project client names for Crew Vacancies</label>
                     </div>
                 </div>
                 {% if "BUSINESS:BUSINESS_SETTINGS:EDIT"|instancePermissions %}

--- a/html/admin/public/embed/jobs.php
+++ b/html/admin/public/embed/jobs.php
@@ -10,6 +10,7 @@ $DBLIB->where("projectsVacantRoles.projectsVacantRoles_visibleToGroups IS NULL")
 $DBLIB->where("(projectsVacantRoles.projectsVacantRoles_deadline IS NULL OR projectsVacantRoles.projectsVacantRoles_deadline >= '" . date("Y-m-d H:i:s") . "')");
 $DBLIB->where("(projectsVacantRoles.projectsVacantRoles_slots > projectsVacantRoles.projectsVacantRoles_slotsFilled)");
 $DBLIB->join("projects","projectsVacantRoles.projects_id=projects.projects_id","LEFT");
+$DBLIB->join("clients", "projects.clients_id=clients.clients_id", "LEFT");
 $DBLIB->join("users", "projects.projects_manager=users.users_userid", "LEFT");
 $DBLIB->where("projects.instances_id", $PAGEDATA['INSTANCE']['instances_id']);
 $DBLIB->where("projects.projects_deleted", 0);
@@ -19,7 +20,7 @@ $DBLIB->orderBy("projects.projects_dates_use_start","ASC");
 $DBLIB->orderBy("projectsVacantRoles.projects_id","ASC");
 $DBLIB->orderBy("projectsVacantRoles.projectsVacantRoles_deadline","ASC");
 $DBLIB->orderBy("projectsVacantRoles.projectsVacantRoles_added","ASC");
-$roles = $DBLIB->get("projectsVacantRoles",null,["projectsVacantRoles.*","projects.*","users.users_userid", "users.users_name1", "users.users_name2", "users.users_email"]);
+$roles = $DBLIB->get("projectsVacantRoles",null,["projectsVacantRoles.*","projects.*", "clients.clients_name", "users.users_userid", "users.users_name1", "users.users_name2", "users.users_email"]);
 $PAGEDATA['roles'] = [];
 foreach($roles as $role) {
     $role['projectsVacantRoles_questions'] = json_decode($role['projectsVacantRoles_questions'],true);

--- a/html/admin/public/embed/jobs.php
+++ b/html/admin/public/embed/jobs.php
@@ -24,6 +24,15 @@ $roles = $DBLIB->get("projectsVacantRoles",null,["projectsVacantRoles.*","projec
 $PAGEDATA['roles'] = [];
 foreach($roles as $role) {
     $role['projectsVacantRoles_questions'] = json_decode($role['projectsVacantRoles_questions'],true);
+
+    //get parent project if set
+    if ($role['projects_parent_project_id']) {
+        $DBLIB->where("projects_id",$role['projects_parent_project_id']);
+        $DBLIB->where("projects_deleted",0);
+        $DBLIB->where("projects_archived",0);
+        $role['parentProject'] = $DBLIB->getOne("projects",["projects_id","projects_name"]);
+    }
+
     $PAGEDATA['roles'][] = $role;
 }
 echo $TWIG->render('public/embed/jobsPublic.twig', $PAGEDATA);

--- a/html/admin/public/embed/jobs.php
+++ b/html/admin/public/embed/jobs.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'head.php';
-if (!isset($PAGEDATA['INSTANCE']['publicData']['enableAssets']) or !$PAGEDATA['INSTANCE']['publicData']['enableVacancies']) die("Disabled by your AdamRMS administrator");
+if (!isset($PAGEDATA['INSTANCE']['publicData']['enableVacancies']) or !$PAGEDATA['INSTANCE']['publicData']['enableVacancies']) die("Disabled by your AdamRMS administrator");
 
 date_default_timezone_set('Europe/London'); //So deadlines show in right timezone
 $PAGEDATA['pageConfig'] = ["TITLE" => "Crew Role Vacancies", "BREADCRUMB" => false];

--- a/html/admin/public/embed/jobs.php
+++ b/html/admin/public/embed/jobs.php
@@ -35,5 +35,8 @@ foreach($roles as $role) {
 
     $PAGEDATA['roles'][] = $role;
 }
+
+$PAGEDATA['showClients'] = (isset($PAGEDATA['INSTANCE']['publicData']['showVacancyClients']) and $PAGEDATA['INSTANCE']['publicData']['showVacancyClients']);
+
 echo $TWIG->render('public/embed/jobsPublic.twig', $PAGEDATA);
 ?>

--- a/html/admin/public/embed/jobsPublic.twig
+++ b/html/admin/public/embed/jobsPublic.twig
@@ -29,6 +29,9 @@
                 <tr>
                     <td>
                         {% if project != role.projects_id %}
+                            {% if role.parentProject %}
+                                {{role.parentProject.projects_name}} &rarr;
+                            {% endif %}
                             {{ role.projects_name }}
                         {% else %}
                             &#8627;
@@ -55,7 +58,13 @@
                     <td class="project-actions text-right">
                         <div class="btn-group">
                             <button type="button" class="btn btn-secondary btn-sm" data-toggle="modal" data-target="#infoModal{{ role.projectsVacantRoles_id }}">More Info</button>
-                            <a type="button" class="btn btn-success btn-sm" target="_blank" href="{{CONFIG.ROOTURL}}/project/crew/vacancies.php">Login to Apply</a>
+                            <a type="button" class="btn btn-success btn-sm" target="_blank" href="{{CONFIG.ROOTURL}}/project/crew/vacancies.php">
+                                {% if role.projectsVacantRoles_firstComeFirstServed %}
+                                Login to Sign Up
+                                {% else %}
+                                Login to Apply
+                                {% endif %}
+                            </a>
                         </div>
                     </td>
                 </tr>

--- a/html/admin/public/embed/jobsPublic.twig
+++ b/html/admin/public/embed/jobsPublic.twig
@@ -8,7 +8,10 @@
                 <th style="width: 15%;">
                     Project
                 </th>
-                <th style="width: 15%;">
+                <th style="width: 15%; min-width:150px;">
+                    Project Client
+                </th>
+                <th style="width: 10%; min-width:200px;">
                     Project Dates
                 </th>
                 <th>
@@ -29,6 +32,11 @@
                             {{ role.projects_name }}
                         {% else %}
                             &#8627;
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if project != role.projects_id %}
+                        {{role.clients_name}}
                         {% endif %}
                     </td>
                     <td>

--- a/html/admin/public/embed/jobsPublic.twig
+++ b/html/admin/public/embed/jobsPublic.twig
@@ -8,9 +8,11 @@
                 <th style="width: 15%;">
                     Project
                 </th>
+                {% if showClients %}
                 <th style="width: 15%; min-width:150px;">
                     Project Client
                 </th>
+                {% endif %}
                 <th style="width: 10%; min-width:200px;">
                     Project Dates
                 </th>
@@ -37,11 +39,13 @@
                             &#8627;
                         {% endif %}
                     </td>
+                    {% if showClients %}
                     <td>
                         {% if project != role.projects_id %}
                         {{role.clients_name}}
                         {% endif %}
                     </td>
+                    {% endif %}
                     <td>
                         {% if project != role.projects_id %}
                             {{role.projects_dates_use_start ? role.projects_dates_use_start|date("d M Y h:ia") }}<br/>


### PR DESCRIPTION
### Description

Initially planned to address #567 for the public embed, this PR also addresses #616 (found on the way), as well as copying changes made to the internal page to the public site.

It feels like it might be worth combining the two somehow to prevent them going out of sync like this.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue is linked to this pull request.
