### PR TITLE
Generate barcode on asset creation

### DIFF
--- a/html/admin/api/assets/newAssetFromType.php
+++ b/html/admin/api/assets/newAssetFromType.php
@@ -27,7 +27,23 @@ if (isset($array['assets_tag']) and $array['assets_tag'] != null) {
 $result = $DBLIB->insert("assets", array_intersect_key( $array, array_flip( ['assets_tag','assetTypes_id','assets_notes','instances_id','asset_definableFields_1','asset_definableFields_2','asset_definableFields_3','asset_definableFields_4','asset_definableFields_5','asset_definableFields_6','asset_definableFields_7','asset_definableFields_8','asset_definableFields_9','asset_definableFields_10','assets_assetGroups'] ) ));
 
 if (!$result) finish(false, ["code" => "INSERT-FAIL", "message"=> "Could not insert asset"]);
-else finish(true, null, ["assets_id" => $result, "assets_tag" => $array['assets_tag'], "assetTypes_id" => $array['assetTypes_id']]);
+
+//Generate asset barcode
+
+$assetBarcodeData = [
+    "assetsBarcodes_value" => "A" . (is_numeric($asset['assets_tag']) ? $asset['assets_tag'] : $asset['assets_id']),
+    "assetsBarcodes_type" => "CODE_128",
+    "assets_id" => $asset['assets_id'],
+    "users_userid" => $AUTH->data['users_userid'],
+    "assetsBarcodes_added" => date("Y-m-d H:i:s")
+];
+while (checkDuplicate($assetBarcodeData["assetsBarcodes_value"],$assetBarcodeData["assetsBarcodes_type"])) {
+    $assetBarcodeData["assetsBarcodes_value"] = mt_rand(1000,99999);
+}
+$insert = $DBLIB->insert("assetsBarcodes", $assetBarcodeData);
+//We don't really mind if the insert fails, we can always generate another one later...
+
+finish(true, null, ["assets_id" => $result, "assets_tag" => $array['assets_tag'], "assetTypes_id" => $array['assetTypes_id']]);
 
 /** @OA\Post(
  *     path="/assets/newAssetFromType.php", 

--- a/html/admin/api/assets/newAssetFromType.php
+++ b/html/admin/api/assets/newAssetFromType.php
@@ -31,14 +31,14 @@ if (!$result) finish(false, ["code" => "INSERT-FAIL", "message"=> "Could not ins
 //Generate asset barcode
 
 $assetBarcodeData = [
-    "assetsBarcodes_value" => "A" . (is_numeric($asset['assets_tag']) ? $asset['assets_tag'] : $asset['assets_id']),
+    "assetsBarcodes_value" => $asset['assets_tag'],
     "assetsBarcodes_type" => "CODE_128",
     "assets_id" => $asset['assets_id'],
     "users_userid" => $AUTH->data['users_userid'],
     "assetsBarcodes_added" => date("Y-m-d H:i:s")
 ];
 while (checkDuplicate($assetBarcodeData["assetsBarcodes_value"],$assetBarcodeData["assetsBarcodes_type"])) {
-    $assetBarcodeData["assetsBarcodes_value"] = mt_rand(1000,99999);
+    $assetBarcodeData["assetsBarcodes_value"] = mt_rand(1000,999999); //Duplicate, so generate a hopefully random number as a replacement
 }
 $insert = $DBLIB->insert("assetsBarcodes", $assetBarcodeData);
 //We don't really mind if the insert fails, we can always generate another one later...

--- a/html/admin/maintenance/barcodePrint.php
+++ b/html/admin/maintenance/barcodePrint.php
@@ -39,14 +39,14 @@ foreach ($ids as $id) {
         $asset['barcode'] = $DBLIB->getone("assetsBarcodes");
         if (!$asset['barcode']) {
             $assetBarcodeData = [
-                "assetsBarcodes_value" => "A" . (is_numeric($asset['assets_tag']) ? $asset['assets_tag'] : $asset['assets_id']),
+                "assetsBarcodes_value" => $asset['assets_tag'],
                 "assetsBarcodes_type" => "CODE_128",
                 "assets_id" => $asset['assets_id'],
                 "users_userid" => $AUTH->data['users_userid'],
                 "assetsBarcodes_added" => date("Y-m-d H:i:s")
             ];
             while (checkDuplicate($assetBarcodeData["assetsBarcodes_value"],$assetBarcodeData["assetsBarcodes_type"])) {
-                $assetBarcodeData["assetsBarcodes_value"] = mt_rand(1000,99999);
+                $assetBarcodeData["assetsBarcodes_value"] = mt_rand(1000,999999);
             }
             $insert = $DBLIB->insert("assetsBarcodes", $assetBarcodeData);
             if ($insert) {


### PR DESCRIPTION
### Description

When an asset is created from an asset type, it will automatically create an associated barcode.

Closes #625 

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [x] I have updated the API documentation for any routes changed, within each api file.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue is linked to this pull request.
