### PR TITLE
Remove default calculation behavior of project finance calculator

### DIFF
--- a/db/migrations/20240320173000_new_project_finance_maths.php
+++ b/db/migrations/20240320173000_new_project_finance_maths.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+
+final class NewProjectFinanceMaths extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function up(): void
+    {
+        $this->execute("alter table projects add projects_dates_finances_days SMALLINT UNSIGNED default NULL null after projects_dates_deliver_end;
+            alter table projects add projects_dates_finances_weeks SMALLINT UNSIGNED default NULL null after projects_dates_finances_days;");
+
+        $builder = $this->getQueryBuilder();
+        $projectsQuery = $builder->select(['projects_id', 'projects_dates_deliver_start', 'projects_dates_deliver_end', 'projects_name'])->from('projects')->execute();
+        $projects = $projectsQuery->fetchAll();
+        
+        foreach ($projects as $project) {
+            if ($project[1] == null || $project[2] == null) {
+                continue;
+            }
+            echo "Starting migration of project " . $project[3] . " dates \n";
+            $return = ["string" => "Project finance migrated in upgrade of AdamRMS. Project number of days & weeks set manually, calculated based on:", "days" => 0, "weeks" => 0];
+            $start = strtotime(date("d F Y 00:00:00", strtotime($project[1])));
+            $end = strtotime(date("d F Y 23:59:59", strtotime($project[2])));
+            if (date("N", $start) == 6) {
+                $return['weeks'] += 1;
+                $return['string'] .= "\nBegins on Saturday so first weekend charged as one week";
+                $start = $start + (86400 * 2);
+            } elseif (date("N", $start) == 7) {
+                $return['weeks'] += 1;
+                $return['string'] .= "\nBegins on Sunday so first weekend charged as one week";
+                $start = $start + 86400;
+            }
+            if (($end-$start) > 259200) { //If it's just one weekend it doesn't count as two weeks
+                if (date("N", $end) == 6) {
+                    $return['weeks'] += 1;
+                    $return['string'] .= "\nEnds on Saturday so last weekend charged as one week";
+                    $end = $end - 86400;
+                } elseif (date("N", $end) == 7) {
+                    $return['weeks'] += 1;
+                    $return['string'] .= "\nEnds on Sunday so last weekend charged as one week";
+                    $end = $end - (86400 * 2);
+                }
+            }
+            $remaining = strtotime(date("d F Y 23:59:59", $end)) - strtotime(date("d F Y", $start));
+            if ($remaining > 0) {
+                $remaining = ceil($remaining / 86400); //Convert to days
+                $weeks = floor($remaining / 7); //Number of week periods
+                if ($weeks > 0) {
+                    $return['weeks'] += $weeks;
+                    if ($weeks == 1) {
+                        $return['string'] .= "\nAdd 1 week period to reflect a period of more than 7 days";
+                    } else {
+                        $return['string'] .= "\nAdd " . $weeks . " week periods to reflect a period of more than 7 days";
+                    }
+                    $remaining = $remaining - ($weeks * 7);
+                }
+                if ($remaining > 2) {
+                    $return['string'] .= "\nAdd a week to discount a period between 3 and 7 days";
+                    $return['weeks'] += 1;
+                    $remaining = $remaining - 7;
+                }
+                if ($remaining > 0) {
+                    $return['days'] += ceil($remaining);
+                    if ($remaining == 1){
+                        $return['string'] .= "\nAdd 1 day period";
+                    } else {
+                        $return['string'] .= "\nAdd " . ceil($remaining) . " day periods";
+                    }
+                }
+            }
+            $projectBuilder = $this->getQueryBuilder();
+            $projectBuilder
+                ->update('projects')
+                ->set(['projects_dates_finances_days' => $return['days'], 'projects_dates_finances_weeks' => $return['weeks']])
+                ->where(['projects_id' => $project[0]])
+                ->execute();
+            $this->table('auditLog')->insert([
+                'auditLog_actionType' => 'CHANGE-DATE-FINANCE',
+                "auditLog_timestamp" =>  date("Y-m-d H:i:s"),
+                'auditLog_actionTable' => 'projects',
+                'auditLog_actionData' => $return['string'],
+                'projects_id' => $project[0],
+            ])->saveData();
+        }
+    }
+}

--- a/html/admin/api/assets/delete.php
+++ b/html/admin/api/assets/delete.php
@@ -27,10 +27,10 @@ else {
     $DBLIB->where("assets_id",$asset['assets_id']);
     $DBLIB->where("assetsAssignments_deleted",0);
     $DBLIB->join("projects","assetsAssignments.projects_id=projects.projects_id","LEFT");
-    $assetAssignments = $DBLIB->get("assetsAssignments",null,['projects.projects_id','projects_dates_deliver_start','assetsAssignments_id','projects_dates_deliver_end','assetsAssignments_customPrice','assetsAssignments_discount']);
+    $assetAssignments = $DBLIB->get("assetsAssignments",null,['projects.projects_id','assetsAssignments_id','assetsAssignments_customPrice','assetsAssignments_discount']);
     foreach ($assetAssignments as $assignment) {
         $projectFinanceHelper = new projectFinance();
-        $priceMaths = $projectFinanceHelper->durationMaths($assignment['projects_dates_deliver_start'],$assignment['projects_dates_deliver_end']);
+        $priceMaths = $projectFinanceHelper->durationMaths($assignment['projects_id']);
         $projectFinanceCacher = new projectFinanceCacher($assignment['projects_id']);
 
         //Remove current mass and value

--- a/html/admin/api/assets/editAsset.php
+++ b/html/admin/api/assets/editAsset.php
@@ -45,10 +45,10 @@ else {
     $DBLIB->where("assets_id",$array['assets_id']);
     $DBLIB->where("assetsAssignments_deleted",0);
     $DBLIB->join("projects","assetsAssignments.projects_id=projects.projects_id","LEFT");
-    $assetAssignments = $DBLIB->get("assetsAssignments",null,['projects.projects_id','projects_dates_deliver_start','assetsAssignments_id','projects_dates_deliver_end','assetsAssignments_customPrice','assetsAssignments_discount']);
+    $assetAssignments = $DBLIB->get("assetsAssignments",null,['projects.projects_id','assetsAssignments_id','assetsAssignments_customPrice','assetsAssignments_discount']);
     foreach ($assetAssignments as $assignment) {
         $projectFinanceHelper = new projectFinance();
-        $priceMaths = $projectFinanceHelper->durationMaths($assignment['projects_dates_deliver_start'],$assignment['projects_dates_deliver_end']);
+        $priceMaths = $projectFinanceHelper->durationMaths($assignment['projects_id']);
         $projectFinanceCacher = new projectFinanceCacher($assignment['projects_id']);
 
         //Remove current mass and value

--- a/html/admin/api/assets/editAssetType.php
+++ b/html/admin/api/assets/editAssetType.php
@@ -39,10 +39,10 @@ else {
         $DBLIB->where("assets_id",$asset['assets_id']);
         $DBLIB->where("assetsAssignments_deleted",0);
         $DBLIB->join("projects","assetsAssignments.projects_id=projects.projects_id","LEFT");
-        $assetAssignments = $DBLIB->get("assetsAssignments",null,['projects.projects_id','projects_dates_deliver_start','assetsAssignments_id','projects_dates_deliver_end','assetsAssignments_customPrice','assetsAssignments_discount']);
+        $assetAssignments = $DBLIB->get("assetsAssignments",null,['projects.projects_id','assetsAssignments_id','assetsAssignments_customPrice','assetsAssignments_discount']);
         foreach ($assetAssignments as $assignment) {
             $projectFinanceHelper = new projectFinance();
-            $priceMaths = $projectFinanceHelper->durationMaths($assignment['projects_dates_deliver_start'],$assignment['projects_dates_deliver_end']);
+            $priceMaths = $projectFinanceHelper->durationMaths($assignment['projects_id']);
             $projectFinanceCacher = new projectFinanceCacher($assignment['projects_id']);
             //Remove current mass and value
             if ($asset['assets_mass'] == null) {

--- a/html/admin/api/projects/assets/assign.php
+++ b/html/admin/api/projects/assets/assign.php
@@ -15,7 +15,7 @@ if ($project["projects_dates_deliver_start"] == null or $project["projects_dates
 
 $projectFinanceHelper = new projectFinance();
 $projectFinanceCacher = new projectFinanceCacher($project['projects_id']);
-$priceMaths = $projectFinanceHelper->durationMaths($project['projects_dates_deliver_start'],$project['projects_dates_deliver_end']);
+$priceMaths = $projectFinanceHelper->durationMaths($project['projects_id']);
 
 $assetRequiredFields = ["assetTypes_name","assets_tag","assets_id","assets_dayRate","assets_weekRate","assetTypes_dayRate","assetTypes_weekRate","assetTypes_mass","assetTypes_value","assets_value","assets_mass","assets_assetGroups"];
 

--- a/html/admin/api/projects/assets/setDiscount.php
+++ b/html/admin/api/projects/assets/setDiscount.php
@@ -11,11 +11,11 @@ if (!$assignmentsSetDiscount['projectid']) finish(false,["message"=>"Cannot find
 $DBLIB->where("projects.projects_id", $assignmentsSetDiscount["projectid"]);
 $DBLIB->where("projects.instances_id", $AUTH->data['instance_ids'], 'IN');
 $DBLIB->where("projects.projects_deleted", 0);
-$project = $DBLIB->getone("projects",["projects_id","projects_dates_deliver_start","projects_dates_deliver_end"]);
+$project = $DBLIB->getone("projects",["projects_id"]);
 if (!$project) finish(false,["message"=>"Cannot find project"]);
 
 $projectFinanceHelper = new projectFinance();
-$priceMaths = $projectFinanceHelper->durationMaths($project['projects_dates_deliver_start'],$project['projects_dates_deliver_end']);
+$priceMaths = $projectFinanceHelper->durationMaths($project['projects_id']);
 $projectFinanceCacher = new projectFinanceCacher($project['projects_id']);
 
 foreach ($assignmentsSetDiscount["assignments"] as $assignment) {

--- a/html/admin/api/projects/assets/setPrice.php
+++ b/html/admin/api/projects/assets/setPrice.php
@@ -17,11 +17,11 @@ if (!$assignmentsSetDiscount['projectid']) finish(false,["message"=>"Cannot find
 $DBLIB->where("projects.projects_id", $assignmentsSetDiscount["projectid"]);
 $DBLIB->where("projects.instances_id", $AUTH->data['instance_ids'], 'IN');
 $DBLIB->where("projects.projects_deleted", 0);
-$project = $DBLIB->getone("projects",["projects_id","projects_dates_deliver_start","projects_dates_deliver_end"]);
+$project = $DBLIB->getone("projects",["projects_id"]);
 if (!$project) finish(false,["message"=>"Cannot find project"]);
 
 $projectFinanceHelper = new projectFinance();
-$priceMaths = $projectFinanceHelper->durationMaths($project['projects_dates_deliver_start'],$project['projects_dates_deliver_end']);
+$priceMaths = $projectFinanceHelper->durationMaths($project['projects_id']);
 $projectFinanceCacher = new projectFinanceCacher($project['projects_id']);
 
 foreach ($assignmentsSetDiscount["assignments"] as $assignment) {

--- a/html/admin/api/projects/assets/unassign.php
+++ b/html/admin/api/projects/assets/unassign.php
@@ -32,11 +32,11 @@ if (!$assignmentsRemove['projectid']) finish(false,["message"=>"Cannot find proj
 $DBLIB->where("projects.projects_id", $assignmentsRemove["projectid"]);
 $DBLIB->where("projects.instances_id", $AUTH->data['instance_ids'], 'IN');
 $DBLIB->where("projects.projects_deleted", 0);
-$project = $DBLIB->getone("projects",["projects_id","projects_dates_deliver_start","projects_dates_deliver_end","projects_name"]);
+$project = $DBLIB->getone("projects",["projects_id","projects_name"]);
 if (!$project) finish(false,["message"=>"Cannot find project"]);
 
 $projectFinanceHelper = new projectFinance();
-$priceMaths = $projectFinanceHelper->durationMaths($project['projects_dates_deliver_start'],$project['projects_dates_deliver_end']);
+$priceMaths = $projectFinanceHelper->durationMaths($project['projects_id']);
 $projectFinanceCacher = new projectFinanceCacher($project['projects_id']);
 
 $assignmentsIDs = [];

--- a/html/admin/api/projects/changeProjectDeliverDates.php
+++ b/html/admin/api/projects/changeProjectDeliverDates.php
@@ -9,13 +9,21 @@ $newDates = ["projects_dates_deliver_start" => date ("Y-m-d H:i:s", strtotime($_
 $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
 $DBLIB->where("projects.projects_deleted", 0);
 $DBLIB->where("projects.projects_id", $_POST['projects_id']);
-$project = $DBLIB->getone("projects", ["projects_id","projects_dates_deliver_start","projects_dates_deliver_end"]);
+$project = $DBLIB->getone("projects", ["projects_id","projects_dates_deliver_start","projects_dates_deliver_end","projects_dates_finances_days", "projects_dates_finances_weeks"]);
 if (!$project) finish(false);
 
 $projectFinanceHelper = new projectFinance();
 $projectFinanceCacher = new projectFinanceCacher($project['projects_id']);
-$priceMathsOld = $projectFinanceHelper->durationMaths($project['projects_dates_deliver_start'],$project['projects_dates_deliver_end']);
-$priceMathsNew = $projectFinanceHelper->durationMaths($newDates['projects_dates_deliver_start'],$newDates['projects_dates_deliver_end']);
+if ($project['projects_dates_finances_days'] !== NULL and $project['projects_dates_finances_weeks'] !== NULL) {
+    // Custom price maths is set, so changing the dates will have no impact on pricing anyway
+    $priceMathsOld = $projectFinanceHelper->durationMaths($project['projects_id']);
+    $priceMathsNew = $priceMathsOld;
+} else {
+    // We need to calculate the price maths because custom price maths is not set
+    $priceMathsOld = $projectFinanceHelper->durationMaths($project['projects_id']);
+    $priceMathsNew = $projectFinanceHelper->durationMathsByDates($newDates['projects_dates_deliver_start'],$newDates['projects_dates_deliver_end']);
+}
+
 
 //We're changing dates so we need to find clashes in the new dates
 $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);

--- a/html/admin/api/projects/changeProjectFinanceDateMaths.php
+++ b/html/admin/api/projects/changeProjectFinanceDateMaths.php
@@ -1,0 +1,118 @@
+<?php
+require_once __DIR__ . '/../apiHeadSecure.php';
+use Money\Currency;
+use Money\Money;
+
+if (!$AUTH->instancePermissionCheck("PROJECTS:EDIT:DATES") or !isset($_POST['projects_id']) or 
+    !isset($_POST['projects_dates_finances_days']) or !isset($_POST['projects_dates_finances_weeks'])) die("404");
+
+$DAYS = intval($_POST['projects_dates_finances_days']);
+$WEEKS = intval($_POST['projects_dates_finances_weeks']);
+$REMOVECUSTOM = $_POST['projects_dates_finances_days'] == -1 and $_POST['projects_dates_finances_weeks'] == -1;
+
+$DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
+$DBLIB->where("projects.projects_deleted", 0);
+$DBLIB->where("projects.projects_id", $_POST['projects_id']);
+$project = $DBLIB->getone("projects", ["projects_id","projects_dates_deliver_start","projects_dates_deliver_end","projects_dates_finances_days", "projects_dates_finances_weeks"]);
+if (!$project) finish(false);
+
+$projectFinanceHelper = new projectFinance();
+$projectFinanceCacher = new projectFinanceCacher($project['projects_id']);
+$priceMathsOld = $projectFinanceHelper->durationMaths($project['projects_id']);
+if ($REMOVECUSTOM) $priceMathsNew = $projectFinanceHelper->durationMathsByDates($project['projects_dates_deliver_start'],$project['projects_dates_deliver_end']);
+else $priceMathsNew = ["days" => $DAYS, "weeks" => $WEEKS];
+
+//We're changing dates so we need to update pricing
+$DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
+$DBLIB->where("assetsAssignments.projects_id", $project['projects_id']);
+$DBLIB->join("assets","assetsAssignments.assets_id=assets.assets_id", "LEFT");
+$DBLIB->join("assetTypes", "assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT");
+$assets = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assets_id", "assetsAssignments.assetsAssignments_id","assetsAssignments_customPrice","assetsAssignments_discount","assetTypes_weekRate","assetTypes_dayRate","assets_dayRate","assets_weekRate"]);
+if ($assets) {
+    foreach ($assets as $asset) {
+        if ($asset['assetsAssignments_customPrice'] != null) continue; //There is a custom price set - so this asset is date agnostic anyway
+
+        $priceOriginal = new Money(null, new Currency($AUTH->data['instance']['instances_config_currency']));
+        $priceOriginal = $priceOriginal->add((new Money(($asset['assets_dayRate'] !== null ? $asset['assets_dayRate'] : $asset['assetTypes_dayRate']), new Currency($AUTH->data['instance']['instances_config_currency'])))->multiply($priceMathsOld['days']));
+        $priceOriginal = $priceOriginal->add((new Money(($asset['assets_weekRate'] !== null ? $asset['assets_weekRate'] : $asset['assetTypes_weekRate']), new Currency($AUTH->data['instance']['instances_config_currency'])))->multiply($priceMathsOld['weeks']));
+        $projectFinanceCacher->adjust('projectsFinanceCache_equipmentSubTotal', $priceOriginal,true);
+
+        $price = new Money(null, new Currency($AUTH->data['instance']['instances_config_currency']));
+        $price = $price->add((new Money(($asset['assets_dayRate'] !== null ? $asset['assets_dayRate'] : $asset['assetTypes_dayRate']), new Currency($AUTH->data['instance']['instances_config_currency'])))->multiply($priceMathsNew['days']));
+        $price = $price->add((new Money(($asset['assets_weekRate'] !== null ? $asset['assets_weekRate'] : $asset['assetTypes_weekRate']), new Currency($AUTH->data['instance']['instances_config_currency'])))->multiply($priceMathsNew['weeks']));
+        $projectFinanceCacher->adjust('projectsFinanceCache_equipmentSubTotal', $price,false);
+
+        if ($asset['assetsAssignments_discount'] > 0) {
+            //Remove old discount
+            $projectFinanceCacher->adjust('projectsFinanceCache_equiptmentDiscounts', $priceOriginal->subtract($priceOriginal->multiply(1 - ($asset['assetsAssignments_discount'] / 100))),true);
+            //Set a new discount
+            $projectFinanceCacher->adjust('projectsFinanceCache_equiptmentDiscounts', $price->subtract($price->multiply(1 - ($asset['assetsAssignments_discount'] / 100))), false);
+        }
+    }
+}
+
+if ($projectFinanceCacher->save()) {
+    $DBLIB->where("projects.projects_id", $project['projects_id']);
+    $projectUpdate = $DBLIB->update("projects", [
+        "projects_dates_finances_days" => $REMOVECUSTOM ? 'NULL' : $DAYS,
+        "projects_dates_finances_weeks" => $REMOVECUSTOM ? 'NULL' : $WEEKS
+    ]);
+    if (!$projectUpdate) finish(false);
+    if ($REMOVECUSTOM) $bCMS->auditLog("CHANGE-DATE-FINANCE", "projects", "Removed custom days & weeks for asset cost calculation", $AUTH->data['users_userid'],null, $_POST['projects_id']);
+    else $bCMS->auditLog("CHANGE-DATE-FINANCE", "projects", "Set custom days & weeks for asset cost calculation to " + $DAYS + " day(s) & " + $WEEKS + " week(s)", $AUTH->data['users_userid'],null, $_POST['projects_id']);
+    finish(true, null, ["changed" => true]);
+} else finish(false, ["message"=>"Cannot modify finances to change dates"]);
+
+/** @OA\Post(
+ *     path="/projects/changeProjectFinanceDateMaths.php", 
+ *     summary="Change Project Number of Days & Weeks for Finance", 
+ *     description="Change the number of days and weeks for a project  
+Requires Instance Permission PROJECTS:EDIT:DATES
+", 
+ *     operationId="changeProjectFinanceDateMaths", 
+ *     tags={"projects"}, 
+ *     @OA\Response(
+ *         response="200", 
+ *         description="Success",
+ *         @OA\MediaType(
+ *             mediaType="application/json", 
+ *             @OA\Schema( 
+ *                 type="object", 
+ *                 @OA\Property(
+ *                     property="result", 
+ *                     type="boolean", 
+ *                     description="Whether the request was successful",
+ *                 ),
+ *             ),
+ *         ),
+ *     ), 
+ *     @OA\Response(
+ *         response="404", 
+ *         description="Permission Error",
+ *     ), 
+ *     @OA\Parameter(
+ *         name="projects_id",
+ *         in="query",
+ *         description="Project ID",
+ *         required="true", 
+ *         @OA\Schema(
+ *             type="number"), 
+ *         ), 
+ *     @OA\Parameter(
+ *         name="projects_dates_finances_days",
+ *         in="query",
+ *         description="Number of days (set both this and weeks to -1 to remove custom)",
+ *         required="true", 
+ *         @OA\Schema(
+ *             type="string"), 
+ *         ), 
+ *     @OA\Parameter(
+ *         name="projects_dates_finances_weeks",
+ *         in="query",
+ *         description="Number of weeks (set both this and weeks to -1 to remove custom)",
+ *         required="true", 
+ *         @OA\Schema(
+ *             type="string"), 
+ *         ), 
+ * )
+ */

--- a/html/admin/api/projects/changeProjectFinanceDurationMaths.php
+++ b/html/admin/api/projects/changeProjectFinanceDurationMaths.php
@@ -1,10 +1,13 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
+
 use Money\Currency;
 use Money\Money;
 
-if (!$AUTH->instancePermissionCheck("PROJECTS:EDIT:DATES") or !isset($_POST['projects_id']) or 
-    !isset($_POST['projects_dates_finances_days']) or !isset($_POST['projects_dates_finances_weeks'])) die("404");
+if (
+    !$AUTH->instancePermissionCheck("PROJECTS:EDIT:DATES") or !isset($_POST['projects_id']) or
+    !isset($_POST['projects_dates_finances_days']) or !isset($_POST['projects_dates_finances_weeks'])
+) die("404");
 
 $DAYS = intval($_POST['projects_dates_finances_days']);
 $WEEKS = intval($_POST['projects_dates_finances_weeks']);
@@ -13,21 +16,21 @@ $REMOVECUSTOM = $_POST['projects_dates_finances_days'] == -1 and $_POST['project
 $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
 $DBLIB->where("projects.projects_deleted", 0);
 $DBLIB->where("projects.projects_id", $_POST['projects_id']);
-$project = $DBLIB->getone("projects", ["projects_id","projects_dates_deliver_start","projects_dates_deliver_end","projects_dates_finances_days", "projects_dates_finances_weeks"]);
+$project = $DBLIB->getone("projects", ["projects_id", "projects_dates_deliver_start", "projects_dates_deliver_end", "projects_dates_finances_days", "projects_dates_finances_weeks"]);
 if (!$project) finish(false);
 
 $projectFinanceHelper = new projectFinance();
 $projectFinanceCacher = new projectFinanceCacher($project['projects_id']);
 $priceMathsOld = $projectFinanceHelper->durationMaths($project['projects_id']);
-if ($REMOVECUSTOM) $priceMathsNew = $projectFinanceHelper->durationMathsByDates($project['projects_dates_deliver_start'],$project['projects_dates_deliver_end']);
+if ($REMOVECUSTOM) $priceMathsNew = $projectFinanceHelper->durationMathsByDates($project['projects_dates_deliver_start'], $project['projects_dates_deliver_end']);
 else $priceMathsNew = ["days" => $DAYS, "weeks" => $WEEKS];
 
 //We're changing dates so we need to update pricing
 $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
 $DBLIB->where("assetsAssignments.projects_id", $project['projects_id']);
-$DBLIB->join("assets","assetsAssignments.assets_id=assets.assets_id", "LEFT");
+$DBLIB->join("assets", "assetsAssignments.assets_id=assets.assets_id", "LEFT");
 $DBLIB->join("assetTypes", "assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT");
-$assets = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assets_id", "assetsAssignments.assetsAssignments_id","assetsAssignments_customPrice","assetsAssignments_discount","assetTypes_weekRate","assetTypes_dayRate","assets_dayRate","assets_weekRate"]);
+$assets = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assets_id", "assetsAssignments.assetsAssignments_id", "assetsAssignments_customPrice", "assetsAssignments_discount", "assetTypes_weekRate", "assetTypes_dayRate", "assets_dayRate", "assets_weekRate"]);
 if ($assets) {
     foreach ($assets as $asset) {
         if ($asset['assetsAssignments_customPrice'] != null) continue; //There is a custom price set - so this asset is date agnostic anyway
@@ -35,16 +38,16 @@ if ($assets) {
         $priceOriginal = new Money(null, new Currency($AUTH->data['instance']['instances_config_currency']));
         $priceOriginal = $priceOriginal->add((new Money(($asset['assets_dayRate'] !== null ? $asset['assets_dayRate'] : $asset['assetTypes_dayRate']), new Currency($AUTH->data['instance']['instances_config_currency'])))->multiply($priceMathsOld['days']));
         $priceOriginal = $priceOriginal->add((new Money(($asset['assets_weekRate'] !== null ? $asset['assets_weekRate'] : $asset['assetTypes_weekRate']), new Currency($AUTH->data['instance']['instances_config_currency'])))->multiply($priceMathsOld['weeks']));
-        $projectFinanceCacher->adjust('projectsFinanceCache_equipmentSubTotal', $priceOriginal,true);
+        $projectFinanceCacher->adjust('projectsFinanceCache_equipmentSubTotal', $priceOriginal, true);
 
         $price = new Money(null, new Currency($AUTH->data['instance']['instances_config_currency']));
         $price = $price->add((new Money(($asset['assets_dayRate'] !== null ? $asset['assets_dayRate'] : $asset['assetTypes_dayRate']), new Currency($AUTH->data['instance']['instances_config_currency'])))->multiply($priceMathsNew['days']));
         $price = $price->add((new Money(($asset['assets_weekRate'] !== null ? $asset['assets_weekRate'] : $asset['assetTypes_weekRate']), new Currency($AUTH->data['instance']['instances_config_currency'])))->multiply($priceMathsNew['weeks']));
-        $projectFinanceCacher->adjust('projectsFinanceCache_equipmentSubTotal', $price,false);
+        $projectFinanceCacher->adjust('projectsFinanceCache_equipmentSubTotal', $price, false);
 
         if ($asset['assetsAssignments_discount'] > 0) {
             //Remove old discount
-            $projectFinanceCacher->adjust('projectsFinanceCache_equiptmentDiscounts', $priceOriginal->subtract($priceOriginal->multiply(1 - ($asset['assetsAssignments_discount'] / 100))),true);
+            $projectFinanceCacher->adjust('projectsFinanceCache_equiptmentDiscounts', $priceOriginal->subtract($priceOriginal->multiply(1 - ($asset['assetsAssignments_discount'] / 100))), true);
             //Set a new discount
             $projectFinanceCacher->adjust('projectsFinanceCache_equiptmentDiscounts', $price->subtract($price->multiply(1 - ($asset['assetsAssignments_discount'] / 100))), false);
         }
@@ -54,14 +57,14 @@ if ($assets) {
 if ($projectFinanceCacher->save()) {
     $DBLIB->where("projects.projects_id", $project['projects_id']);
     $projectUpdate = $DBLIB->update("projects", [
-        "projects_dates_finances_days" => $REMOVECUSTOM ? 'NULL' : $DAYS,
-        "projects_dates_finances_weeks" => $REMOVECUSTOM ? 'NULL' : $WEEKS
+        "projects_dates_finances_days" => $REMOVECUSTOM ? null : $DAYS,
+        "projects_dates_finances_weeks" => $REMOVECUSTOM ? null : $WEEKS
     ]);
     if (!$projectUpdate) finish(false);
-    if ($REMOVECUSTOM) $bCMS->auditLog("CHANGE-DATE-FINANCE", "projects", "Removed custom days & weeks for asset cost calculation", $AUTH->data['users_userid'],null, $_POST['projects_id']);
-    else $bCMS->auditLog("CHANGE-DATE-FINANCE", "projects", "Set custom days & weeks for asset cost calculation to " + $DAYS + " day(s) & " + $WEEKS + " week(s)", $AUTH->data['users_userid'],null, $_POST['projects_id']);
+    if ($REMOVECUSTOM) $bCMS->auditLog("CHANGE-DATE-FINANCE", "projects", "Removed custom days & weeks for asset cost calculation", $AUTH->data['users_userid'], null, $_POST['projects_id']);
+    else $bCMS->auditLog("CHANGE-DATE-FINANCE", "projects", "Set custom days & weeks for asset cost calculation to " . $DAYS . " day(s) & " . $WEEKS . " week(s)", $AUTH->data['users_userid'], null, $_POST['projects_id']);
     finish(true, null, ["changed" => true]);
-} else finish(false, ["message"=>"Cannot modify finances to change dates"]);
+} else finish(false, ["message" => "Cannot modify finances to change dates"]);
 
 /** @OA\Post(
  *     path="/projects/changeProjectFinanceDateMaths.php", 

--- a/html/admin/api/projects/data.php
+++ b/html/admin/api/projects/data.php
@@ -97,7 +97,7 @@ function projectFinancials($project) {
     $return['value'] = new Money(null, new Currency($AUTH->data['instance']['instances_config_currency']));
     $return['prices'] = ["subTotal" => new Money(null, new Currency($AUTH->data['instance']['instances_config_currency'])), "discounts" => new Money(null, new Currency($AUTH->data['instance']['instances_config_currency'])), "total" => new Money(null, new Currency($AUTH->data['instance']['instances_config_currency']))];
 
-    $return['priceMaths'] = $projectFinanceHelper->durationMaths($project['projects_dates_deliver_start'],$project['projects_dates_deliver_end']);
+    $return['priceMaths'] = $projectFinanceHelper->durationMaths($project['projects_id']);
     foreach ($assets as $asset) {
         $return['mass'] += ($asset['assets_mass'] == null ? $asset['assetTypes_mass'] : $asset['assets_mass']);
         $asset['value'] = new Money(($asset['assets_value'] != null ? $asset['assets_value'] : $asset['assetTypes_value']), new Currency($AUTH->data['instance']['instances_config_currency']));

--- a/html/admin/project/project_assets.twig
+++ b/html/admin/project/project_assets.twig
@@ -228,7 +228,7 @@
             if (selected.length > 0) {
                 bootbox.prompt({
                     title: "Set Discount",
-                    message: "Discounts the selected assets by a percentage.<br /><br />E.g. Inputting 20 would multiply the price by 0.8<br />This will override any existing discounts set in this project for the assets selected.",
+                    message: "Discounts the selected assets by a percentage.<br /><br />E.g. Inputting 20 would multiply the price by 0.8, inputting 100 would set the price to 0, or inputting 0 would be full price.<br />This will override any existing discounts set in this project for the assets selected.",
                     inputType: 'number',
                     min: 0,
                     max: 100,

--- a/html/admin/project/project_assets.twig
+++ b/html/admin/project/project_assets.twig
@@ -67,12 +67,11 @@
                 <p style="font-style: italic;">To view assets assigned to this project, select a business above</p>
                 <p>{{ (FINANCIALS.assetsAssigned|length + FINANCIALS.assetsAssignedSUB|length) }} Asset{{ (FINANCIALS.assetsAssigned|length + FINANCIALS.assetsAssignedSUB|length) != 1 ? 's' }} assigned to {{ project.projects_name }} ({{FINANCIALS.mass|mass }})</p>
                 {% if project.projectsTypes_config_finance == 1 %}
-                    <h5>Hire Charges</h5>
-                    <p>
-                        Days: {{ FINANCIALS['priceMaths']["days"] }}<br/>
-                        Weeks: {{ FINANCIALS['priceMaths']["weeks"] }}
+                    <p>Project duration set as {{ FINANCIALS['priceMaths']["weeks"] }} week{{ FINANCIALS['priceMaths']["weeks"] != 1 ? 's' : '' }} and {{ FINANCIALS['priceMaths']["days"] }} day{{ FINANCIALS['priceMaths']["days"] != 1 ? 's' : ''}} for asset pricing purposes.
+                    {% if "PROJECTS:EDIT:DATES"|instancePermissions %}
+                    <a href="{{ CONFIG.ROOTURL }}/project/?id={{ project.projects_id }}">Change project duration</a>.
+                    {% endif %}
                     </p>
-                    <p>{{ FINANCIALS['priceMaths']["string"]|nl2br }}</p>
                 {% endif %}
             </div>
             <div class="tab-pane fade" id="asset-list-tabs-thisinstance" role="tabpanel" aria-labelledby="asset-list-tabs-profile-tab">

--- a/html/admin/project/project_index.twig
+++ b/html/admin/project/project_index.twig
@@ -242,6 +242,32 @@
                                                                 <b class="d-block">{{project.projects_dates_deliver_start ? project.projects_dates_deliver_start|date("Y-m-d h:i:sa") ~ ' - ' ~ project.projects_dates_deliver_end|date("Y-m-d h:i:sa") }}</b>
                                                             {% endif %}
                                                             </p>
+                                                            <p class="text-sm">Project duration for asset pricing purposes
+                                                            {% if "PROJECTS:EDIT:DATES"|instancePermissions %}
+                                                                <div class="input-group">
+                                                                    <div class="input-group-prepend">
+                                                                        <span class="input-group-text">Weeks</span>
+                                                                    </div>
+                                                                    <input type="number" min="0" step="1" max="256" value="{{ FINANCIALS['priceMaths']["weeks"] }}" class="form-control float-right" required id="financeDurationMathsWeeks">
+                                                                    <span class="input-group-text">Days</span>
+                                                                    <input type="number" min="0" step="1" max="256" value="{{ FINANCIALS['priceMaths']["days"] }}" class="form-control float-right" required id="financeDurationMathsDays">
+                                                                    <div class="input-group-append">
+                                                                        <button class="btn btn-default" type="button" id="financeDurationMathsSave">Save</button>
+                                                                    </div>
+                                                                </div>
+                                                                {% if project.projects_dates_use_start %}
+                                                                <div style="width: 100%;text-align: right;">
+                                                                    {% if project.projects_dates_finances_days == null and project.projects_dates_finances_weeks == null %}
+                                                                        Project duration is currently based on project dates
+                                                                    {% else %}
+                                                                     <a href="#" id="copyProjectDatesToFinanceDurationMaths">Set from Project Dates ({{ FINANCIALS['priceMaths']["calendarDays"] }} day{{ FINANCIALS['priceMaths']["calendarDays"] == 1 ? '' : 's' }})</a>
+                                                                    {% endif %}
+                                                                </div>
+                                                                {% endif %}
+                                                            {% else %}
+                                                                <b class="d-block">{{ FINANCIALS['priceMaths']["weeks"] }} week{{ FINANCIALS['priceMaths']["weeks"] != 1 ? 's' : '' }} and {{ FINANCIALS['priceMaths']["days"] }} day{{ FINANCIALS['priceMaths']["days"] != 1 ? 's' : ''}}</b>
+                                                            {% endif %}
+                                                            </p>
                                                         {% endif %}
                                                     </div>
                                                     <br/>
@@ -1073,6 +1099,19 @@
                 changeProjectDeliverDates($("#datePickerInput").data('daterangepicker').startDate.format('DD MMM YYYY hh:mm A'),$("#datePickerInput").data('daterangepicker').endDate.format('DD MMM YYYY hh:mm A'));
             });
 
+            function setFinanceDurationMathsWeeks(weeks, days) {
+                ajaxcall("projects/changeProjectFinanceDurationMaths.php", {"projects_id": "{{ project.projects_id }}","projects_dates_finances_weeks":weeks,"projects_dates_finances_days":days}, function (data) {
+                    location.reload();
+                });
+            }
+            $("#financeDurationMathsSave").click(function () {
+                var days = $("#financeDurationMathsDays").val();
+                var weeks = $("#financeDurationMathsWeeks").val();
+                setFinanceDurationMathsWeeks(weeks, days);
+            });
+            $("#copyProjectDatesToFinanceDurationMaths").click(function () {
+                setFinanceDurationMathsWeeks("-1", "-1");
+            });
 
             {% endif %}
             {% if "PROJECTS:EDIT:NAME"|instancePermissions %}

--- a/html/admin/project/project_index.twig
+++ b/html/admin/project/project_index.twig
@@ -257,10 +257,10 @@
                                                                 </div>
                                                                 {% if project.projects_dates_use_start %}
                                                                 <div style="width: 100%;text-align: right;">
-                                                                    {% if project.projects_dates_finances_days == null and project.projects_dates_finances_weeks == null %}
+                                                                    {% if project.projects_dates_finances_days is same as(null) and project.projects_dates_finances_weeks is same as (null) %}
                                                                         Project duration is currently based on project dates
                                                                     {% else %}
-                                                                     <a href="#" id="copyProjectDatesToFinanceDurationMaths">Set from Project Dates ({{ FINANCIALS['priceMaths']["calendarDays"] }} day{{ FINANCIALS['priceMaths']["calendarDays"] == 1 ? '' : 's' }})</a>
+                                                                     <a href="#" id="copyProjectDatesToFinanceDurationMaths">Sync to Project Dates ({{ FINANCIALS['priceMaths']["calendarDays"] }} day{{ FINANCIALS['priceMaths']["calendarDays"] == 1 ? '' : 's' }})</a>
                                                                     {% endif %}
                                                                 </div>
                                                                 {% endif %}

--- a/html/admin/project/project_log.twig
+++ b/html/admin/project/project_log.twig
@@ -5,7 +5,7 @@
             <div class="timeline">
                 {% set currentDate = '' %}
                 {% for event in project.auditLog %}
-                    {% if event.auditLog_actionType in ['QUICKCOMMENT', 'INSERT', 'ARCHIVE','UNARCHIVE','CHANGE-MANAGER','UPDATE-NAME','UPDATE-STATUS','CHANGE-DATE','UPDATE-DESCRIPTION','CHANGE-CLIENT'] %}
+                    {% if event.auditLog_actionType in ['QUICKCOMMENT', 'INSERT', 'ARCHIVE','UNARCHIVE','CHANGE-MANAGER','UPDATE-NAME','UPDATE-STATUS','CHANGE-DATE','CHANGE-DATE-FINANCE','UPDATE-DESCRIPTION','CHANGE-CLIENT'] %}
                         {% if event.auditLog_timestamp|date("Y-m-d") != currentDate %}
                             <div class="time-label">
                                 <span class="bg-red">{{ event.auditLog_timestamp|date("D jS M Y") }}</span>

--- a/html/admin/project/twigIncludes/assetList/tableItem.twig
+++ b/html/admin/project/twigIncludes/assetList/tableItem.twig
@@ -69,7 +69,7 @@
     </td>
     <td>{{ assetAssignment.assets_mass != null ? assetAssignment.assets_mass|mass : (assetAssignment.assetTypes_mass != null and assetAssignment.assetTypes_mass != 0 ? assetAssignment.assetTypes_mass|mass : "") }}</td>
     {% if project.projectsTypes_config_finance == 1 %}
-        <td>{{ assetAssignment.price|money }}</td>
+        <td>{{ assetAssignment.price|money }}{{ assetAssignment.assetsAssignments_customPrice > 0 ? '&nbsp;<span class="badge badge-info" title="Custom price set"><i class="fas fa-coins"></i></span>' :'' }}</td>
         <td>{{ assetAssignment.discountPrice|money }}{{  assetAssignment.assetsAssignments_discount > 0 ? " ("~assetAssignment.assetsAssignments_discount ~ "%)" : "" }}</td>
     {% endif %}
 </tr>

--- a/html/common/coreHead.php
+++ b/html/common/coreHead.php
@@ -420,7 +420,7 @@ class projectFinance {
         $end = strtotime(date("d F Y 23:59:59", strtotime($end)));
         $diff = ceil(($end - $start) / 86400);
         if ($diff < 1) $diff = 1;
-        return ["string" => "Counted number of days between dates", "days" => $diff, "weeks" => 0];
+        return ["days" => $diff, "weeks" => 0, "calendarDays" => $diff];
     }
     public function durationMaths($projects_id) {
         global $DBLIB;
@@ -429,7 +429,8 @@ class projectFinance {
         if (!$project) return false;
 
         if ($project['projects_dates_finances_days'] !== NULL and $project['projects_dates_finances_weeks'] !== NULL) {
-            return ["string" => "Custom days & weeks set", "days" => $project['projects_dates_finances_days'], "weeks" => $project['projects_dates_finances_weeks']];
+            $rawDays = $this->durationMathsByDates($project['projects_dates_deliver_start'], $project['projects_dates_deliver_end']);
+            return ["days" => $project['projects_dates_finances_days'], "weeks" => $project['projects_dates_finances_weeks'], "calendarDays" => $rawDays['days']];
         } else {
             return $this->durationMathsByDates($project['projects_dates_deliver_start'], $project['projects_dates_deliver_end']);
         }

--- a/html/common/coreHead.php
+++ b/html/common/coreHead.php
@@ -415,60 +415,24 @@ function assetLatestScan($assetid) {
 
 }
 class projectFinance {
-    public function durationMaths($projects_dates_deliver_start,$projects_dates_deliver_end) {
-        //Calculate the default pricing for all assets
-        $return = ["string" => "Calculated based on:", "days" => 0, "weeks" => 0];
-        $start = strtotime(date("d F Y 00:00:00", strtotime($projects_dates_deliver_start)));
-        $end = strtotime(date("d F Y 23:59:59", strtotime($projects_dates_deliver_end)));
-        if (date("N", $start) == 6) {
-            $return['weeks'] += 1;
-            $return['string'] .= "\nBegins on Saturday so first weekend charged as one week";
-            $start = $start + (86400 * 2);
-        } elseif (date("N", $start) == 7) {
-            $return['weeks'] += 1;
-            $return['string'] .= "\nBegins on Sunday so first weekend charged as one week";
-            $start = $start + 86400;
-        }
-        if (($end-$start) > 259200) { //If it's just one weekend it doesn't count as two weeks
-            if (date("N", $end) == 6) {
-                $return['weeks'] += 1;
-                $return['string'] .= "\nEnds on Saturday so last weekend charged as one week";
-                $end = $end - 86400;
-            } elseif (date("N", $end) == 7) {
-                $return['weeks'] += 1;
-                $return['string'] .= "\nEnds on Sunday so last weekend charged as one week";
-                $end = $end - (86400 * 2);
-            }
-        }
+    public function durationMathsByDates($start, $end) {
+        $start = strtotime(date("d F Y 00:00:00", strtotime($start)));
+        $end = strtotime(date("d F Y 23:59:59", strtotime($end)));
+        $diff = ceil(($end - $start) / 86400);
+        if ($diff < 1) $diff = 1;
+        return ["string" => "Counted number of days between dates", "days" => $diff, "weeks" => 0];
+    }
+    public function durationMaths($projects_id) {
+        global $DBLIB;
+        $DBLIB->where("projects_id", $projects_id);
+        $project = $DBLIB->getone("projects", ["projects_dates_finances_days", "projects_dates_finances_weeks", "projects_dates_deliver_start", "projects_dates_deliver_end"]);
+        if (!$project) return false;
 
-        $remaining = strtotime(date("d F Y 23:59:59", $end)) - strtotime(date("d F Y", $start));
-        if ($remaining > 0) {
-            $remaining = ceil($remaining / 86400); //Convert to days
-            $weeks = floor($remaining / 7); //Number of week periods
-            if ($weeks > 0) {
-                $return['weeks'] += $weeks;
-                if ($weeks == 1) {
-                    $return['string'] .= "\nAdd 1 week period to reflect a period of more than 7 days";
-                } else {
-                    $return['string'] .= "\nAdd " . $weeks . " week periods to reflect a period of more than 7 days";
-                }
-                $remaining = $remaining - ($weeks * 7);
-            }
-            if ($remaining > 2) {
-                $return['string'] .= "\nAdd a week to discount a period between 3 and 7 days";
-                $return['weeks'] += 1;
-                $remaining = $remaining - 7;
-            }
-            if ($remaining > 0) {
-                $return['days'] += ceil($remaining);
-                if ($remaining == 1){
-                    $return['string'] .= "\nAdd 1 day period";
-                } else {
-                    $return['string'] .= "\nAdd " . ceil($remaining) . " day periods";
-                }
-            }
+        if ($project['projects_dates_finances_days'] !== NULL and $project['projects_dates_finances_weeks'] !== NULL) {
+            return ["string" => "Custom days & weeks set", "days" => $project['projects_dates_finances_days'], "weeks" => $project['projects_dates_finances_weeks']];
+        } else {
+            return $this->durationMathsByDates($project['projects_dates_deliver_start'], $project['projects_dates_deliver_end']);
         }
-        return $return;
     }
 }
 use Money\Money;


### PR DESCRIPTION
### Description

@adamskrz raises the point that the current project finance calculator is over-specific, and requires extensive use of the custom price feature to appropriately price the vast majority of projects. 

This PR removes the previous calculation system, and instead moves to a default setup where project finance is calculated soley on the basis of days, unless a custom number of days/weeks are provided. The migration sets custom days & weeks for existing projects to ensure the pricing remains consistent.

Additionally, an icon is shown when a custom price is set for a particular asset on that project: ![image](https://github.com/adam-rms/adam-rms/assets/8408967/929387f9-59f4-4e57-aa0a-8fd7b6702cc2)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [x] I have updated the API documentation for any routes changed, within each api file.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue is linked to this pull request.
