### PR TITLE
Let browser set barcode height dynamically

### DIFF
--- a/src/maintenance/barcode.twig
+++ b/src/maintenance/barcode.twig
@@ -73,7 +73,7 @@
                 </div>
                 <div class="card-body" id="barcodeScanVideoCard">
                     <button class="btn btn-success btn-lg" title="Start Scanning" id="barcodeScanStartButton">Start Scanning</button>
-                    <video id="barcodeScanVideo" width="1920" height="1080" style="border: 0;"></video>
+                    <video id="barcodeScanVideo" width="1920" style="border: 0;"></video>
                 </div>
                 <div class="card-footer" id="barcodeScanSourceSelectPanel" >
                     <div class="input-group my-2" style="display: none;">
@@ -461,7 +461,6 @@
 
             const barcodeScanVideoWidth = $("#barcodeScanVideoCard").width()
             $("#barcodeScanVideo").attr("width", barcodeScanVideoWidth)
-            $("#barcodeScanVideo").attr("height", barcodeScanVideoWidth*1.7)
 
             const codeReader = new ZXing.BrowserMultiFormatReader();
 


### PR DESCRIPTION
### Description

Let browser set barcode scanner image height dynamically

### Checklist

- [ ] I accept the contributor license agreement for this repository.
- [ ] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [ ] I have updated the API documentation for any routes changed, within each api file.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used (if not `main`).
- [ ] A GitHub issue is linked to this pull request.
