### PR TITLE
Allow email footers to be customised

### DIFF
--- a/src/api/notifications/email/email.php
+++ b/src/api/notifications/email/email.php
@@ -19,7 +19,7 @@ function sendEmail($user, $instanceID, $subject, $html = false, $template = fals
         $instance = $DBLIB->getone("userInstances", ["instances.instances_name", "instances.instances_address", "instances.instances_emailHeader"]);
     } else $instance = false;
 
-    $outputHTML = $TWIG->render('api/notifications/email/email_template.twig', ["SUBJECT" => $subject, "HTML"=> $bCMS->cleanString($html), "CONFIG" => $CONFIG, "DATA" => $emailData, "TEMPLATE" => $template, "INSTANCE" => $instance]); // Subject is escaped by twig, but the HTML is not.
+    $outputHTML = $TWIG->render('api/notifications/email/email_template.twig', ["SUBJECT" => $subject, "HTML"=> $bCMS->cleanString($html), "CONFIG" => $CONFIG, "DATA" => $emailData, "TEMPLATE" => $template, "INSTANCE" => $instance, "FOOTER" => $CONFIGCLASS->get('EMAILS_FOOTER')]); // Subject is escaped by twig, but the HTML is not.
 
     switch ($CONFIGCLASS->get('EMAILS_PROVIDER')) {
         case 'Sendgrid':

--- a/src/api/notifications/email/email_template.twig
+++ b/src/api/notifications/email/email_template.twig
@@ -271,8 +271,10 @@
             <tr>
                 <td style="padding: 20px; font-family: sans-serif; font-size: 12px; line-height: 15px; text-align: center; color: #888888;">
                     <br/>
-                    {% if INSTANCE %}Delivered for {{ INSTANCE.instances_name }} by AdamRMS<br/>{% endif %}<span class="unstyle-auto-detected-links">AdamRMS is a Bithell Studios Ltd. Project<br/>160 Kemp House City Road<br/>London, EC1V 2NX<br/>United Kingdom<br/>Company &#8470;11918238</span>
-                    <br><br>If you don't want to receive emails like these you can disable them in your account settings
+                    {% if INSTANCE %}Delivered for {{ INSTANCE.instances_name }} by AdamRMS.<br/>{% endif %}
+                    If you don't want to receive emails like these you can disable them in your account settings.
+                    <br/>
+                    {{ FOOTER|raw }}
                 </td>
             </tr>
         </table>
@@ -284,35 +286,6 @@
         </table>
         <![endif]-->
     </div>
-
-    <!-- Full Bleed Background Section : BEGIN -->
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #f87e9e;">
-        <tr>
-            <td>
-                <div align="center" style="max-width: 600px; margin: auto;" class="email-container">
-                    <!--[if mso]>
-                    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" align="center">
-                        <tr>
-                            <td>
-                    <![endif]-->
-                    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-                        <tr>
-                            <td style="padding: 20px; text-align: left; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #ffffff;">
-                                <p style="margin: 0;">AdamRMS is a fully-featured asset, project and rental management platform for Theatre, AV & Broadcast. To find out more about what it could do for your business, get in touch at studios@jbithell.com</p>
-                            </td>
-                        </tr>
-                    </table>
-                    <!--[if mso]>
-                    </td>
-                    </tr>
-                    </table>
-                    <![endif]-->
-                </div>
-            </td>
-        </tr>
-    </table>
-    <!-- Full Bleed Background Section : END -->
-
     <!--[if mso | IE]>
     </td>
     </tr>

--- a/src/common/libs/Config/configStructureArray.php
+++ b/src/common/libs/Config/configStructureArray.php
@@ -243,7 +243,7 @@ $configStructureArray = [
       },
       "name" => "Email Footer",
       "group" => "Email",
-      "description" => "Footer for emails being sent from AdamRMS",
+      "description" => "Footer for emails.",
       "required" => false,
       "maxlength" => 65535,
       "minlength" => 0,

--- a/src/common/libs/Config/configStructureArray.php
+++ b/src/common/libs/Config/configStructureArray.php
@@ -235,6 +235,27 @@ $configStructureArray = [
     "default" => 465,
     "envFallback" => "CONFIG_EMAILS_SMTP_PORT",
   ],
+  "EMAILS_FOOTER" => [
+    "form" => [
+      "type" => "text",
+      "default" => function () {
+        return null;
+      },
+      "name" => "Email Footer",
+      "group" => "Email",
+      "description" => "Footer for emails being sent from AdamRMS",
+      "required" => false,
+      "maxlength" => 65535,
+      "minlength" => 0,
+      "options" => [],
+      "verifyMatch" => function ($value, $options) {
+        return ["valid" => true, "value" => $value, "error" => null];
+      }
+    ],
+    "specialRequest" => true,
+    "default" => "<br/>AdamRMS is a fully-featured asset, project and rental management platform for Theatre, AV & Broadcast. To find out more about what it could do for your business, visit <a href=\"https://adam-rms.com\">adam-rms.com</a>.",
+    "envFallback" => false,
+  ],
   "ERRORS_PROVIDERS_SENTRY" => [
     "form" => [
       "type" => "secret",


### PR DESCRIPTION
### Description

Allow email footers to be customised, to reduce the Bithell Studios branding

### Checklist

- [ ] I accept the contributor license agreement for this repository.
- [ ] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [ ] I have updated the API documentation for any routes changed, within each api file.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used (if not `main`).
- [ ] A GitHub issue is linked to this pull request.
