### PR TITLE
Delay downloading invoices/quotes for Firefox

### DIFF
--- a/src/api/s3files/uploadProjectInvoice.php
+++ b/src/api/s3files/uploadProjectInvoice.php
@@ -44,6 +44,7 @@ if (isset($_FILES['file'])) {
         else finish(true, null, ["id" => $id, "resize" => false, "url" => $CONFIG['ROOTURL'] . '/api/file/?r=true&f=' . $id]);
     } else finish(false, ["code" => null, "message" => "S3 Upload Error"]);
 }
+finish(false, ["code" => null, "message" => "HTTP Upload Error"]);
 /** @OA\Post(
  *     path="/s3files/uploadProjectInvoice.php", 
  *     summary="Upload Project Invoice", 

--- a/src/project/pdf.twig
+++ b/src/project/pdf.twig
@@ -502,7 +502,8 @@
             var pdf = pdfMake.createPdf(docDefinition);
             {% if GET['draft'] or CONFIG.FILES_ENABLED != "Enabled" or USERDATA.instance.instances_storageEnabled != 1 %}
             pdf.download("{{ project['projects_name']|escape("js") }} - Draft {{ GET['quote'] ? "Quote" : "Invoice" }}.pdf", function() {
-                window.close();
+                // Firefox takes a bit longer to do file actions, so delay closing this tab a little
+                setTimeout(() => {window.close()}, 100)
             });
             {% else %}
             pdf.getBlob((blob) => {
@@ -522,10 +523,9 @@
                     } else if (response.error && response.error.code) {
                         alert(response.error.message);
                     } else if (response.result && response.response && response.response.url) {
-                        //window.location = response.response.url;
-                        //pdf.open({}, window);
                         pdf.download("{{ project['projects_name']|escape("js") }} - {{ GET['quote'] ? "Quote" : "Invoice" }} v{{ fileNumber|escape("js") }}.pdf", function() {
-                            window.close();
+                            // Firefox takes a bit longer to do file actions, so delay closing this tab a little
+                            setTimeout(() => {window.close()}, 100)
                         });
                     } else {
                         alert("Error loading PDF");

--- a/src/project/project_index.twig
+++ b/src/project/project_index.twig
@@ -589,16 +589,12 @@
                         </button>
                     </div>
                     <div class="modal-body">
-{% embed 'assets/templates/fileBox.twig' with {'files': payment.files } %}
-
-
+                        {% embed 'assets/templates/fileBox.twig' with {'files': payment.files } %}
                         {% endembed %}
                     </div>
                     {% if "PROJECTS:PROJECT_PAYMENTS:CREATE:FILE_ATTACHMENTS"|instancePermissions %}
                         <div class="modal-footer">
-{% embed 'assets/templates/uppy.twig' with {'type': 'PAYMENT-FILE', 'paste': true, 'typeId': 14, 'subTypeId': payment.payments_id, 'imagesOnly': false } %}
-
-
+                            {% embed 'assets/templates/uppy.twig' with {'type': 'PAYMENT-FILE', 'paste': true, 'typeId': 14, 'subTypeId': payment.payments_id, 'imagesOnly': false } %}
                                 {% block success %}
                                     console.log(responseJson.id);
                                 {% endblock %}
@@ -622,16 +618,12 @@
                     </button>
                 </div>
                 <div class="modal-body">
-{% embed 'assets/templates/fileBox.twig' with {'files': files } %}
-
-
+                    {% embed 'assets/templates/fileBox.twig' with {'files': files } %}
                     {% endembed %}
                 </div>
                 {% if "PROJECTS:PROJECT_FLIE_ATTACHMENTS:CREATE"|instancePermissions %}
                     <div class="modal-footer">
-{% embed 'assets/templates/uppy.twig' with {'type': 'PROJECT-FILE', 'paste': true, 'typeId': 7, 'subTypeId': project.projects_id, 'imagesOnly': false } %}
-
-
+                        {% embed 'assets/templates/uppy.twig' with {'type': 'PROJECT-FILE', 'paste': true, 'typeId': 7, 'subTypeId': project.projects_id, 'imagesOnly': false } %}
                             {% block success %}
                                 console.log(responseJson.id);
                             {% endblock %}
@@ -652,7 +644,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-{% embed 'assets/templates/fileBox.twig' with {'files': quotes } %}
+                    {% embed 'assets/templates/fileBox.twig' with {'files': quotes } %}
 
 
                     {% endembed %}
@@ -670,9 +662,7 @@
                     </button>
                 </div>
                 <div class="modal-body">
-{% embed 'assets/templates/fileBox.twig' with {'files': invoices } %}
-
-
+                    {% embed 'assets/templates/fileBox.twig' with {'files': invoices } %}
                     {% endembed %}
                 </div>
             </div>


### PR DESCRIPTION
### Description
Firefox needs a bit more time to handle downloads, so this adds a delay to ensure they actually happen

Closes #624  (ish...)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [x] I have updated the API documentation for any routes changed, within each api file.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue is linked to this pull request.
