### PR TITLE
Allow editing of Asset Category Groups

### DIFF
--- a/db/migrations/20241016073836_update_asset_categories.php
+++ b/db/migrations/20241016073836_update_asset_categories.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+final class UpdateAssetCategories extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $this->table('assetCategoriesGroups')
+            ->addColumn('instances_id', 'integer')
+            ->addColumn('assetCategoriesGroups_deleted', 'boolean', [
+                'null' => false,
+                'default' => '0',
+                'limit' => MysqlAdapter::INT_TINY,
+                'after' => 'instances_id',
+            ])
+            ->addIndex(['instances_id'], [
+                'name' => 'assetCategoriesGroups_instances_instances_id_fk',
+                'unique' => false,
+            ])
+            ->addForeignKey('instances_id', 'instances', 'instances_id', [
+                'constraint' => 'assetCategoriesGroups_instances_instances_id_fk',
+                'update' => 'CASCADE',
+                'delete' => 'CASCADE',
+            ])
+            ->save();
+    }
+}

--- a/db/seeds/AssetCategorySeeder.php
+++ b/db/seeds/AssetCategorySeeder.php
@@ -21,61 +21,81 @@ class AssetCategorySeeder extends AbstractSeed
                 "assetCategoriesGroups_id" => 1,
                 "assetCategoriesGroups_name" => "Lighting",
                 "assetCategoriesGroups_fontAwesome" => "far fa-lightbulb",
-                "assetCategoriesGroups_order" => 1
+                "assetCategoriesGroups_order" => 1,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ],
             [
                 "assetCategoriesGroups_id" => 2,
                 "assetCategoriesGroups_name" => "Sound",
                 "assetCategoriesGroups_fontAwesome" => "fas fa-volume-up",
-                "assetCategoriesGroups_order" => 2
+                "assetCategoriesGroups_order" => 2,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ],
             [
                 "assetCategoriesGroups_id" => 3,
                 "assetCategoriesGroups_name" => "Video",
                 "assetCategoriesGroups_fontAwesome" => "fas fa-tv",
-                "assetCategoriesGroups_order" => 3
+                "assetCategoriesGroups_order" => 3,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ],
             [
                 "assetCategoriesGroups_id" => 4,
                 "assetCategoriesGroups_name" => "Rigging",
                 "assetCategoriesGroups_fontAwesome" => "fas fa-balance-scale-left",
-                "assetCategoriesGroups_order" => 4
+                "assetCategoriesGroups_order" => 4,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ],
             [
                 "assetCategoriesGroups_id" => 5,
                 "assetCategoriesGroups_name" => "Computers & Networks",
                 "assetCategoriesGroups_fontAwesome" => "fas fa-server",
-                "assetCategoriesGroups_order" => 6
+                "assetCategoriesGroups_order" => 6,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ],
             [
                 "assetCategoriesGroups_id" => 6,
                 "assetCategoriesGroups_name" => "Communication",
                 "assetCategoriesGroups_fontAwesome" => "fas fa-headset",
-                "assetCategoriesGroups_order" => 5
+                "assetCategoriesGroups_order" => 5,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ],
             [
                 "assetCategoriesGroups_id" => 10,
                 "assetCategoriesGroups_name" => "Costume",
                 "assetCategoriesGroups_fontAwesome" => null,
-                "assetCategoriesGroups_order" => 10
+                "assetCategoriesGroups_order" => 10,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ],
             [
                 "assetCategoriesGroups_id" => 11,
                 "assetCategoriesGroups_name" => "Props",
                 "assetCategoriesGroups_fontAwesome" => null,
-                "assetCategoriesGroups_order" => 11
+                "assetCategoriesGroups_order" => 11,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ],
             [
                 "assetCategoriesGroups_id" => 12,
                 "assetCategoriesGroups_name" => "Scenery",
                 "assetCategoriesGroups_fontAwesome" => null,
-                "assetCategoriesGroups_order" => 12
+                "assetCategoriesGroups_order" => 12,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ],
             [
                 "assetCategoriesGroups_id" => 999,
                 "assetCategoriesGroups_name" => "Miscellaneous",
                 "assetCategoriesGroups_fontAwesome" => "fas fa-question",
-                "assetCategoriesGroups_order" => 999
+                "assetCategoriesGroups_order" => 999,
+                "instances_id" => null,
+                "assetCategoriesGroups_deleted" => 0
             ]
         ];
         $categoryData = [

--- a/src/api/categories/groups/edit.php
+++ b/src/api/categories/groups/edit.php
@@ -1,0 +1,92 @@
+<?php
+require_once __DIR__ . '/../../apiHeadSecure.php';
+
+if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_CATEGORIES:EDIT")) die("404");
+
+$array = [];
+foreach ($_POST['formData'] as $item) {
+    $array[$item['name']] = $item['value'];
+}
+if (strlen($array['assetCategoriesGroups_id']) < 1) finish(false, ["code" => "PARAM-ERROR", "message" => "No data for action"]);
+
+$DBLIB->where("instances_id", $AUTH->data['instance']['instances_id']);
+$DBLIB->where("assetCategoriesGroups_deleted", 0);
+$DBLIB->where("assetCategoriesGroups_id", $array['assetCategoriesGroups_id']);
+$category = $DBLIB->update("assetCategoriesGroups", $array);
+if (!$category) finish(false);
+
+$bCMS->auditLog("EDIT", "assetCategoriesGroups", json_encode($array), $AUTH->data['users_userid']);
+finish(true);
+
+/** @OA\Post(
+ *     path="/categories/edit.php", 
+ *     summary="Edit Asset Category Group", 
+ *     description="Edit an Asset Category Group (Parent)", 
+ *     operationId="editCategoryGroup", 
+ *     tags={"categories"}, 
+ *     @OA\Response(
+ *         response="200", 
+ *         description="Success",
+ *         @OA\MediaType(
+ *             mediaType="application/json", 
+ *             @OA\Schema( 
+ *                 type="object", 
+ *                 @OA\Property(
+ *                     property="result", 
+ *                     type="boolean", 
+ *                     description="Whether the request was successful",
+ *                 ),
+ *                 @OA\Property(
+ *                     property="response", 
+ *                     type="array", 
+ *                     description="A null Array",
+ *                 ),
+ *             ),
+ *         ),
+ *     ), 
+ *     @OA\Response(
+ *         response="default", 
+ *         description="Error",
+ *         @OA\MediaType(
+ *             mediaType="application/json", 
+ *             @OA\Schema( 
+ *                 type="object", 
+ *                 @OA\Property(
+ *                     property="result", 
+ *                     type="boolean", 
+ *                     description="Whether the request was successful",
+ *                 ),
+ *                 @OA\Property(
+ *                     property="error", 
+ *                     type="array", 
+ *                     description="An Array containing an error code and a message",
+ *                 ),
+ *             ),
+ *         ),
+ *     ), 
+ *     @OA\Parameter(
+ *         name="formData",
+ *         in="query",
+ *         description="The category group data",
+ *         required="true", 
+ *         @OA\Schema(
+ *             type="object", 
+ *             @OA\Property(
+ *                 property="assetCategoriesGroups_id", 
+ *                 type="integer", 
+ *                 description="The ID of the category group",
+ *             ),
+ *             @OA\Property(
+ *                 property="assetCategoriesGroups_name", 
+ *                 type="string", 
+ *                 description="The new name of the category group",
+ *             ),
+ *             @OA\Property(
+ *                 property="assetCategoriesGroups_fontAwesome", 
+ *                 type="string", 
+ *                 description="The font awesome icon for the category group",
+ *             ),
+ *         ),
+ *     ), 
+ * )
+ */

--- a/src/api/categories/groups/new.php
+++ b/src/api/categories/groups/new.php
@@ -1,0 +1,84 @@
+<?php
+require_once __DIR__ . '/../../apiHeadSecure.php';
+
+if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_CATEGORIES:EDIT")) die("404");
+
+$array = [];
+foreach ($_POST['formData'] as $item) {
+    $array[$item['name']] = $item['value'];
+}
+if (strlen($array['assetCategoriesGroups_name']) <1) finish(false, ["code" => "PARAM-ERROR", "message"=> "No data for action"]);
+$array['instances_id'] = $AUTH->data['instance']['instances_id'];
+$category = $DBLIB->insert("assetCategoriesGroups", $array);
+if (!$category) finish(false);
+
+$bCMS->auditLog("INSERT", "assetCategoriesGroups", json_encode($array), $AUTH->data['users_userid']);
+finish(true);
+
+/** @OA\Post(
+ *     path="/categories/new.php", 
+ *     summary="Create Asset Category Group", 
+ *     description="Create a new asset category group", 
+ *     operationId="createCategoryGroup", 
+ *     tags={"categories"}, 
+ *     @OA\Response(
+ *         response="200", 
+ *         description="Success",
+ *         @OA\MediaType(
+ *             mediaType="application/json", 
+ *             @OA\Schema( 
+ *                 type="object", 
+ *                 @OA\Property(
+ *                     property="result", 
+ *                     type="boolean", 
+ *                     description="Whether the request was successful",
+ *                 ),
+ *                 @OA\Property(
+ *                     property="response", 
+ *                     type="array", 
+ *                     description="A null Array",
+ *                 ),
+ *             ),
+ *         ),
+ *     ), 
+ *     @OA\Response(
+ *         response="default", 
+ *         description="Error",
+ *         @OA\MediaType(
+ *             mediaType="application/json", 
+ *             @OA\Schema( 
+ *                 type="object", 
+ *                 @OA\Property(
+ *                     property="result", 
+ *                     type="boolean", 
+ *                     description="Whether the request was successful",
+ *                 ),
+ *                 @OA\Property(
+ *                     property="error", 
+ *                     type="array", 
+ *                     description="An Array containing an error code and a message",
+ *                 ),
+ *             ),
+ *         ),
+ *     ), 
+ *     @OA\Parameter(
+ *         name="formData",
+ *         in="query",
+ *         description="The category group data",
+ *         required="true", 
+ *         @OA\Schema(
+ *             type="object", 
+ *             @OA\Property(
+ *                 property="assetCategoriesGroups_name", 
+ *                 type="string", 
+ *                 description="The name of the new category group",
+ *             ),
+ *             @OA\Property(
+ *                 property="assetCategoriesGroups_fontAwesome", 
+ *                 type="string", 
+ *                 description="The font awesome icon for the category group",
+ *             ),
+ *         ),
+ *     ), 
+ * )
+ */

--- a/src/api/categories/search.php
+++ b/src/api/categories/search.php
@@ -27,9 +27,11 @@ if($instanceID == $AUTH->data['instance']["instances_id"]) { // For transfering 
 }
 $DBLIB->orderBy("assetCategoriesGroups.assetCategoriesGroups_order", "ASC");
 $DBLIB->orderBy("assetCategories_rank", "ASC");
-$DBLIB->where("assetCategories_deleted",0);
-$DBLIB->where("(instances_id IS NULL OR instances_id = '" . $instanceID . "')");
-if (isset($_POST['term']) and $_POST['term']) $DBLIB->where("assetCategories_name","%" . $_POST['term'] . "%","LIKE");
+$DBLIB->where("assetCategoriesGroups.assetCategoriesGroups_deleted", 0);
+$DBLIB->where("(assetCategoriesGroups.instances_id IS NULL OR assetCategoriesGroups.instances_id = '" . $instanceID . "')");
+$DBLIB->where("assetCategories.assetCategories_deleted", 0);
+$DBLIB->where("(assetCategories.instances_id IS NULL OR assetCategories.instances_id = '" . $instanceID . "')");
+if (isset($_POST['term']) and $_POST['term']) $DBLIB->where("assetCategories.assetCategories_name", "%" . $_POST['term'] . "%", "LIKE");
 $DBLIB->join("assetCategoriesGroups", "assetCategoriesGroups.assetCategoriesGroups_id=assetCategories.assetCategoriesGroups_id", "LEFT");
 $categories = $DBLIB->get('assetCategories');
 finish(true, [], $categories);

--- a/src/asset.php
+++ b/src/asset.php
@@ -68,7 +68,7 @@ $DBLIB->orderBy("manufacturers_name", "ASC");
 $PAGEDATA['manufacturers'] = $DBLIB->get('manufacturers', null, ["manufacturers.manufacturers_id", "manufacturers.manufacturers_name"]);
 
 $DBLIB->orderBy("assetCategories_rank", "ASC");
-$DBLIB->where("(instances_id IS NULL OR instances_id = '" . $PAGEDATA['ASSET_INSTANCE']["instances_id"] . "')");
+$DBLIB->where("(assetCategories.instances_id IS NULL OR assetCategories.instances_id = '" . $PAGEDATA['ASSET_INSTANCE']["instances_id"] . "')");
 $DBLIB->where("assetCategories_deleted", 0);
 $DBLIB->join("assetCategoriesGroups", "assetCategoriesGroups.assetCategoriesGroups_id=assetCategories.assetCategoriesGroups_id", "LEFT");
 $PAGEDATA['categories'] = $DBLIB->get('assetCategories');

--- a/src/instances/customCategories.php
+++ b/src/instances/customCategories.php
@@ -1,27 +1,20 @@
 <?php
 require_once __DIR__ . '/../common/headSecure.php';
-use Money\Currency;
-use Money\Money;
 
 $PAGEDATA['pageConfig'] = ["TITLE" => "Custom Categories", "BREADCRUMB" => false];
 
 if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_CATEGORIES:VIEW")) die($TWIG->render('404.twig', $PAGEDATA));
 
-if (isset($_GET['q'])) $PAGEDATA['search'] = $bCMS->sanitizeString($_GET['q']);
-else $PAGEDATA['search'] = null;
-
-$DBLIB->orderBy("assetCategoriesGroups.assetCategoriesGroups_order", "ASC");
-$DBLIB->orderBy("assetCategories.assetCategories_rank", "ASC");
-if (strlen($PAGEDATA['search']) > 0) {
-    //Search
-    $DBLIB->where("(
-		assetCategories.assetCategories_name LIKE '%" . $bCMS->sanitizeStringMYSQL($PAGEDATA['search']) . "%' 
-    )");
-}
 $DBLIB->where("(instances_id IS NULL OR instances_id = '" . $AUTH->data['instance']["instances_id"] . "')");
-$DBLIB->where("assetCategories_deleted",0);
-$DBLIB->join("assetCategoriesGroups", "assetCategoriesGroups.assetCategoriesGroups_id=assetCategories.assetCategoriesGroups_id", "LEFT");
-$PAGEDATA['categories'] = $DBLIB->get('assetCategories');
+$DBLIB->where("assetCategoriesGroups_deleted", 0);
+$DBLIB->orderBy("assetCategoriesGroups_order", "ASC");
+$PAGEDATA['categoryGroups'] = $DBLIB->get("assetCategoriesGroups");
+
+foreach ($PAGEDATA['categoryGroups'] as $key => $group) {
+  $DBLIB->where("(instances_id IS NULL OR instances_id = '" . $AUTH->data['instance']["instances_id"] . "')");
+  $DBLIB->where("assetCategories_deleted", 0);
+  $DBLIB->where("assetCategoriesGroups_id", $group['assetCategoriesGroups_id']);
+  $PAGEDATA['categoryGroups'][$key]['categories'] = $DBLIB->get('assetCategories');
+}
 
 echo $TWIG->render('instances/customCategories.twig', $PAGEDATA);
-?>

--- a/src/instances/customCategories.twig
+++ b/src/instances/customCategories.twig
@@ -25,116 +25,153 @@
                     Categories
                 </h3>
                 <div class="card-tools pull-right">
-                    <form class="input-group input-group-sm" method="GET">
-                        <input type="text" name="q" class="form-control" placeholder="Search" value="{{ search }}" />
-                        <div class="input-group-append">
-                            <button type="submit" class="btn btn-default"><i class="fa fa-search"></i></button>
-                            {% if "ASSETS:ASSET_CATEGORIES:CREATE"|instancePermissions %}
-                                <button type="button" class="btn btn-default" data-toggle="modal" data-target="#newModal"><i class="fa fa-plus"></i></button>
-                            {% endif %}
-                        </div>
-                    </form>
+                    <div class="btn-group">
+                        {% if "ASSETS:ASSET_CATEGORIES:CREATE"|instancePermissions %}
+                            <button type="button" aria-label="Create new Asset Category Group" class="btn btn-default btn-sm" data-toggle="modal" data-target="#newGroupModal"><i class="fa fa-plus"></i> Group</button>
+                            <button type="button" aria-label="Create new Asset Category" class="btn btn-default btn-sm" data-toggle="modal" data-target="#newModal"><i class="fa fa-plus"></i> Category</button>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
             <div class="card-body table-responsive p-0">
                 <table class="table table-bordered">
-                    {% set currentCategoryGroup = false %}
-                    {% for category in categories %}
-                        {% if currentCategoryGroup != category.assetCategoriesGroups_name %}
-                        {% if currentCategoryGroup %}
-                            {# Close the previous one for starting a new one #}
-                            </tbody>
-                    {% endif %}
-                        {% set currentCategoryGroup = category.assetCategoriesGroups_name %}
-                            <thead>
+                    {% for group in categoryGroups %}
+                        {% if group.categories|length > 0 %}
+                        <thead>
                             <tr>
-                                <td style="width:15px;"><i class="{{ category.assetCategoriesGroups_fontAwesome }}"></i></td>
-                                <td colspan="2">
-                                    <b>{{ category.assetCategoriesGroups_name }}</b>
+                                <td style="width:15px;"><i class="{{ group.assetCategoriesGroups_fontAwesome }}"></i></td>
+                                <td>
+                                    <b>{{ group.assetCategoriesGroups_name }}</b>
                                 </td>
-                            </tr>
-                            </thead>
-                            <tbody>
-                    {% endif %}
-                          <tr>
-                              <td>
-                                  <i class="{{ category.assetCategories_fontAwesome }}"></i>
-                              </td>
-                              <td>
-                                  {{category.assetCategories_name}}
-                              </td>
-                              <td style="width:70px;">
-                                <div class="btn-group">
-                                    <a type="button" title="View assets" class="btn btn-default btn-sm" href="{{CONFIG.ROOTURL}}/assets.php?category%5B%5D={{ category.assetCategories_id }}&showlinked=1&showarchived=1"><i class="nav-icon fas fa-warehouse"></i></a>
-                                    {% if category.instances_id is not null %}
+                                <td>
+                                    <div class="btn-group">
+                                    {% if group.instances_id is not null %}
                                         {% if "ASSETS:ASSET_CATEGORIES:EDIT"|instancePermissions %}
-                                            <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#editModal{{ category.assetCategories_id }}"><i class="fas fa-edit"></i></button>
+                                            <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#editModal{{ group.assetCategoriesGroups_id }}"><i class="fas fa-edit"></i></button>
                                         {% endif %}
                                         {% if "ASSETS:ASSET_CATEGORIES:DELETE"|instancePermissions %}
-                                            <button type="button" class="btn btn-danger btn-sm deleteButton" data-id="{{ category.assetCategories_id }}"><i class="fas fa-trash"></i></button>
+                                            <button type="button" class="btn btn-danger btn-sm deleteGroupButton" data-id="{{ group.assetCategoriesGroups_id }}"><i class="fas fa-trash"></i></button>
                                         {% endif %}
                                     {% endif %}
-                                 </div>
-                              </td>
-                          </tr>
-                                {% if category.instances_id is not null %}
-                                <div class="modal fade" id="editModal{{ category.assetCategories_id }}">
-                                    <div class="modal-dialog">
-                                        <div class="modal-content">
-                                            <div class="modal-header">
-                                                <h4 class="modal-title">Edit {{category.assetCategories_name}}</h4>
-                                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                                    <span aria-hidden="true">&times;</span>
-                                                </button>
-                                            </div>
-                                            <div class="modal-body">
-                                                <form class="edit-form" data-id="{{ category.assetCategories_id }}">
-                                                    <input type="hidden" name="assetCategories_id" value="{{ category.assetCategories_id }}"/>
-                                                    <div class="input-group" style="margin-bottom: 5px;">
-                                                        <div class="input-group-prepend">
-                                                            <span class="input-group-text">Name</span>
+                                    </div>
+                                </td>
+                            </tr>
+                            {% if group.instances_id is not null %}
+                                    <div class="modal fade" id="editModal{{ group.assetCategoriesGroups_id }}">
+                                        <div class="modal-dialog">
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <h4 class="modal-title">Edit {{group.assetCategoriesGroups_name}}</h4>
+                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <form class="editGroup-form" data-id="{{ group.assetCategoriesGroups_id }}">
+                                                        <input type="hidden" name="assetCategoriesGroups_id" value="{{ group.assetCategoriesGroups_id }}"/>
+                                                        <div class="input-group" style="margin-bottom: 5px;">
+                                                            <div class="input-group-prepend">
+                                                                <span class="input-group-text">Name</span>
+                                                            </div>
+                                                            <input type="text" class="form-control" name="assetCategoriesGroups_name" value="{{ group.assetCategoriesGroups_name }}">
                                                         </div>
-                                                        <input type="text" class="form-control" name="assetCategories_name" value="{{ category.assetCategories_name }}">
-                                                    </div>
-                                                    <div class="input-group" style="margin-bottom: 5px;">
-                                                        <div class="input-group-prepend">
-                                                            <span class="input-group-text">Icon</span>
-                                                        </div>
-                                                        <select class="form-control rms-icon-picker" name="assetCategories_fontAwesome">
-                                                            {% if category.assetCategories_fontAwesome %}
-                                                                <option value="{{ category.assetCategories_fontAwesome }}"></option>
-                                                            {% endif %}
-                                                        </select>
-                                                    </div>
-                                                    <div class="input-group">
-                                                        <div class="input-group-prepend">
-                                                            <span class="input-group-text">Category Group</span>
-                                                        </div>
-                                                        <select class="form-control" name="assetCategoriesGroups_id">
-                                                            {% set currentCategoryGroupSub = false %}
-                                                            {% for categorySub in categories %}
-                                                                {% if currentCategoryGroupSub != categorySub.assetCategoriesGroups_name %}
-                                                                    {% set currentCategoryGroupSub = categorySub.assetCategoriesGroups_name %}
-                                                                    <option {% if category.assetCategoriesGroups_id == categorySub.assetCategoriesGroups_id %}selected{% endif %} value="{{ categorySub.assetCategoriesGroups_id }}">{{ categorySub.assetCategoriesGroups_name }}</option>
+                                                        <div class="input-group" style="margin-bottom: 5px;">
+                                                            <div class="input-group-prepend">
+                                                                <span class="input-group-text">Icon</span>
+                                                            </div>
+                                                            <select class="form-control rms-icon-picker" name="assetCategoriesGroups_fontAwesome">
+                                                                {% if group.assetCategoriesGroups_fontAwesome %}
+                                                                    <option value="{{ group.assetCategoriesGroups_fontAwesome }}"></option>
                                                                 {% endif %}
-                                                            {% endfor %}
-                                                        </select>
-                                                    </div>
-                                                </form>
-                                            </div>
-                                            <div class="modal-footer justify-content-between">
-                                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                                                <button type="button" class="btn btn-primary saveEdit-button" data-id="{{ category.assetCategories_id }}">Save changes</button>
+                                                            </select>
+                                                        </div>
+                                                    </form>
+                                                </div>
+                                                <div class="modal-footer justify-content-between">
+                                                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                                    <button type="button" class="btn btn-primary saveEditGroup-button" data-id="{{ group.assetCategoriesGroups_id }}">Save changes</button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
-                                </div>
+                                {% endif %}
+                        </thead>
+                        <tbody>
+                            {% for category in group.categories %}
+                            <tr>
+                                <td>
+                                    <i class="{{ category.assetCategories_fontAwesome }}"></i>
+                                </td>
+                                <td>
+                                    {{category.assetCategories_name}}
+                                </td>
+                                <td style="width:70px;">
+                                    <div class="btn-group">
+                                        <a type="button" title="View assets" class="btn btn-default btn-sm" href="{{CONFIG.ROOTURL}}/assets.php?category%5B%5D={{ category.assetCategories_id }}&showlinked=1&showarchived=1"><i class="nav-icon fas fa-warehouse"></i></a>
+                                        {% if category.instances_id is not null %}
+                                            {% if "ASSETS:ASSET_CATEGORIES:EDIT"|instancePermissions %}
+                                                <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#editModal{{ category.assetCategories_id }}"><i class="fas fa-edit"></i></button>
+                                            {% endif %}
+                                            {% if "ASSETS:ASSET_CATEGORIES:DELETE"|instancePermissions %}
+                                                <button type="button" class="btn btn-danger btn-sm deleteButton" data-id="{{ category.assetCategories_id }}"><i class="fas fa-trash"></i></button>
+                                            {% endif %}
+                                        {% endif %}
+                                    </div>
+                                </td>
+                            </tr>
+                                {% if category.instances_id is not null %}
+                                    <div class="modal fade" id="editModal{{ category.assetCategories_id }}">
+                                        <div class="modal-dialog">
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <h4 class="modal-title">Edit {{category.assetCategories_name}}</h4>
+                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <form class="edit-form" data-id="{{ category.assetCategories_id }}">
+                                                        <input type="hidden" name="assetCategories_id" value="{{ category.assetCategories_id }}"/>
+                                                        <div class="input-group" style="margin-bottom: 5px;">
+                                                            <div class="input-group-prepend">
+                                                                <span class="input-group-text">Name</span>
+                                                            </div>
+                                                            <input type="text" class="form-control" name="assetCategories_name" value="{{ category.assetCategories_name }}">
+                                                        </div>
+                                                        <div class="input-group" style="margin-bottom: 5px;">
+                                                            <div class="input-group-prepend">
+                                                                <span class="input-group-text">Icon</span>
+                                                            </div>
+                                                            <select class="form-control rms-icon-picker" name="assetCategories_fontAwesome">
+                                                                {% if category.assetCategories_fontAwesome %}
+                                                                    <option value="{{ category.assetCategories_fontAwesome }}"></option>
+                                                                {% endif %}
+                                                            </select>
+                                                        </div>
+                                                        <div class="input-group">
+                                                            <div class="input-group-prepend">
+                                                                <span class="input-group-text">Category Group</span>
+                                                            </div>
+                                                            <select class="form-control" name="assetCategoriesGroups_id">
+                                                                {% for localgroup in categoryGroups %}
+                                                                        <option {% if category.assetCategoriesGroups_id == localgroup.assetCategoriesGroups_id %}selected{% endif %} value="{{ localgroup.assetCategoriesGroups_id }}">{{ localgroup.assetCategoriesGroups_name }}</option>
+                                                                {% endfor %}
+                                                            </select>
+                                                        </div>
+                                                    </form>
+                                                </div>
+                                                <div class="modal-footer justify-content-between">
+                                                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                                    <button type="button" class="btn btn-primary saveEdit-button" data-id="{{ category.assetCategories_id }}">Save changes</button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 {% endif %}
                             {% endfor %}
-                            {% if currentCategoryGroup %}
-                            {# Close the previous category group if you had any #}
-                            </tbody>
-                    {% endif %}
+                        </tbody>
+                        {% endif %}
+                    {% endfor %}
                 </table>
             </div>
         </div>
@@ -144,7 +181,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h4 class="modal-title">New Custom Category</h4>
+                    <h4 class="modal-title">New Asset Category</h4>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
@@ -168,12 +205,8 @@
                                 <span class="input-group-text">Category Group</span>
                             </div>
                             <select required class="form-control" name="assetCategoriesGroups_id">
-                                {% set currentCategoryGroupSub = false %}
-                                {% for categorySub in categories %}
-                                    {% if currentCategoryGroupSub != categorySub.assetCategoriesGroups_name %}
-                                        {% set currentCategoryGroupSub = categorySub.assetCategoriesGroups_name %}
-                                        <option value="{{ categorySub.assetCategoriesGroups_id }}">{{ categorySub.assetCategoriesGroups_name }}</option>
-                                    {% endif %}
+                                {% for group in categoryGroups %}
+                                        <option value="{{ group.assetCategoriesGroups_id }}">{{ group.assetCategoriesGroups_name }}</option>
                                 {% endfor %}
                             </select>
                         </div>
@@ -181,7 +214,39 @@
                 </div>
                 <div class="modal-footer justify-content-between">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                    <button type="button" class="btn btn-primary" id="saveNewCategory">Save changes</button>
+                    <button type="button" class="btn btn-primary" id="saveNewCategory">Create</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal fade" id="newGroupModal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">New Asset Category Group</h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <form id="newCategoryGroupForm">
+                        <div class="input-group" style="margin-bottom: 5px;">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">Name</span>
+                            </div>
+                            <input required type="text" class="form-control" name="assetCategoriesGroups_name">
+                        </div>
+                        <div class="input-group" style="margin-bottom: 5px;">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">Icon</span>
+                            </div>
+                            <select class="form-control rms-icon-picker" name="assetCategoriesGroups_fontAwesome"></select>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer justify-content-between">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-primary" id="saveNewCategoryGroup">Create</button>
                 </div>
             </div>
         </div>
@@ -236,12 +301,23 @@
                     location.reload();
                 });
             });
+            $("#saveNewCategoryGroup").click(function () {
+                var formData = $("#newCategoryGroupForm").serializeArray();
+                ajaxcall("categories/groups/new.php", {formData}, function (data) {
+                    location.reload();
+                });
+            });
             {% endif %}
             {% if "ASSETS:ASSET_CATEGORIES:EDIT"|instancePermissions %}
             $(".saveEdit-button").click(function () {
                 var formData = $(".edit-form[data-id=" + $(this).data("id") + "]").serializeArray();
-                console.log(formData);
                 ajaxcall("categories/edit.php", {formData}, function (data) {
+                    location.reload();
+                });
+            });
+            $(".saveEditGroup-button").click(function () {
+                var formData = $(".editGroup-form[data-id=" + $(this).data("id") + "]").serializeArray();
+                ajaxcall("categories/groups/edit.php", {formData}, function (data) {
                     location.reload();
                 });
             });
@@ -266,6 +342,31 @@
                         if (result) {
                             var formData = [{"name": "assetCategories_id", "value":id },{"name": "assetCategories_deleted", "value":"1" }];
                             ajaxcall("categories/edit.php", {formData}, function (data) {
+                                location.reload();
+                            });
+                        }
+                    }
+                });
+            });
+            $(".deleteGroupButton").click(function () {
+                var id = $(this).data("id");
+                bootbox.confirm({
+                    title:"Are you sure?",
+                    message: "This will delete this group and any categories within it. Categories aren't fully deleted until all assets in the category are moved to other categories",
+                    buttons: {
+                        confirm: {
+                            label: 'Yes',
+                            className: 'btn-danger'
+                        },
+                        cancel: {
+                            label: 'No',
+                            className: 'btn-success'
+                        }
+                    },
+                    callback: function (result) {
+                        if (result) {
+                            var formData = [{"name": "assetCategoriesGroups_id", "value":id },{"name": "assetCategoriesGroups_deleted", "value":"1" }];
+                            ajaxcall("categories/groups/edit.php", {formData}, function (data) {
                                 location.reload();
                             });
                         }

--- a/src/newAsset.php
+++ b/src/newAsset.php
@@ -9,9 +9,12 @@ $DBLIB->where("(manufacturers.instances_id IS NULL OR manufacturers.instances_id
 $DBLIB->orderBy("manufacturers_name", "ASC");
 $PAGEDATA['manufacturers'] = $DBLIB->get('manufacturers', null, ["manufacturers.manufacturers_id", "manufacturers.manufacturers_name"]);
 
-$DBLIB->orderBy("assetCategories_rank", "ASC");
-$DBLIB->where("assetCategories_deleted",0);
-$DBLIB->where("(instances_id IS NULL OR instances_id = '" . $AUTH->data['instance']["instances_id"] . "')");
+$DBLIB->orderBy("assetCategoriesGroups.assetCategoriesGroups_order", "ASC");
+$DBLIB->orderBy("assetCategories.assetCategories_rank", "ASC");
+$DBLIB->where("assetCategories.assetCategories_deleted", 0);
+$DBLIB->where("(assetCategories.instances_id IS NULL OR assetCategories.instances_id = '" . $AUTH->data['instance']["instances_id"] . "')");
+$DBLIB->where("assetCategoriesGroups.assetCategoriesGroups_deleted", 0);
+$DBLIB->where("(assetCategoriesGroups.instances_id IS NULL OR assetCategoriesGroups.instances_id = '" . $AUTH->data['instance']["instances_id"] . "')");
 $DBLIB->join("assetCategoriesGroups", "assetCategoriesGroups.assetCategoriesGroups_id=assetCategories.assetCategoriesGroups_id", "LEFT");
 $PAGEDATA['categories'] = $DBLIB->get('assetCategories');
 


### PR DESCRIPTION
### Description

Allows editing of Asset Category Groups. Deletion follows the same logic as Asset Categories

Closes #657 

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [x] I have updated the API documentation for any routes changed, within each api file.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue is linked to this pull request.
