### PR TITLE
Allow authentication session lengths to be configured

### DIFF
--- a/src/common/libs/Auth/main.php
+++ b/src/common/libs/Auth/main.php
@@ -55,8 +55,7 @@ class bID
 
         if (!$tokenCheck) {
             throw new AuthFail('Token not found in DB');
-        } elseif ((strtotime($tokenCheck["authTokens_created"]) + (12 * 60 * 60)) < time()) {
-             // Tokens are valid for 12 hrs (this includes the mobile app), which matches the session timeout
+        } elseif ((strtotime($tokenCheck["authTokens_created"]) + $CONFIG['AUTH_SESSION_LENGTH']) < time()) {
             throw new AuthFail("Token expired at " . $tokenCheck["authTokens_created"] . " - server time is " . time());
         } elseif (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
             if ($_SERVER["HTTP_CF_CONNECTING_IP"] != $tokenCheck["authTokens_ipAddress"]) {
@@ -286,7 +285,7 @@ class bID
             "iss" => $CONFIG['ROOTURL'],
             "uid" => $userID,
             "token" => $token,
-            "exp" => time()+12*60*60, //12 hours token expiry
+            "exp" => time() + $CONFIG['AUTH_SESSION_LENGTH'],
             "iat" => time(),
             "type" => $type
         ), $CONFIG['AUTH_JWTKey']);

--- a/src/common/libs/Config/configStructureArray.php
+++ b/src/common/libs/Config/configStructureArray.php
@@ -327,6 +327,27 @@ $configStructureArray = [
     "default" => "sha256",
     "envFallback" => false,
   ],
+  "AUTH_SESSION_LENGTH" => [
+    "form" => [
+      "type" => "number",
+      "default" => function () {
+        return 43200;
+      },
+      "name" => "Login session length",
+      "group" => "Security & Login",
+      "description" => "How long a user's login session should last in seconds. Shorter sessions are more secure, but will require users to log in more often. Changing this will affect active and recently expired sessions - It is recommended to leave this at 43200 (12 Hours)",
+      "required" => false,
+      "maxlength" => 6,
+      "minlength" => 4,
+      "options" => [],
+      "verifyMatch" => function ($value, $options) {
+        return ["valid" => true, "value" => $value, "error" => ''];
+      }
+    ],
+    "specialRequest" => false,
+    "default" => 43200,
+    "envFallback" => false,
+  ],
   "AUTH_PROVIDERS_GOOGLE_KEYS_ID" => [
     "form" => [
       "type" => "text",


### PR DESCRIPTION
### Description

Adds config for the length of an authentication session to be adjusted at server level (Min 1000s, Max 999999s)

Closes #714 

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [x] I have updated the API documentation for any routes changed, within each api file.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue is linked to this pull request.
