### PR TITLE
Add storage location to Assets

### DIFF
--- a/db/migrations/20250130190000_add_barcodes_to_all_locations.php
+++ b/db/migrations/20250130190000_add_barcodes_to_all_locations.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+final class AddBarcodesToAllLocations extends AbstractMigration
+{
+
+    /**
+     * Add barcodes to all locations, which is now enabled by default.
+     * Previously they were only created if you clicked the icon next to the barcode - which created odd behaviour with assets
+     */
+    public function change(): void
+    {
+        $builder = $this->getQueryBuilder();
+        $locationsQuery = $builder->select(['locations_id'])->from('locations')->execute();
+        $locations = $locationsQuery->fetchAll();
+
+        foreach ($locations as $location) {
+            $builderLocationBarcode = $this->getQueryBuilder();
+            $locationBarcodeQuery = $builderLocationBarcode->select(['locationsBarcodes_id'])->from('locationsBarcodes')->where(['locations_id' => $location[0]])->execute();
+            $locationBarcode = $locationBarcodeQuery->fetchAll();
+            if (count($locationBarcode) > 0)
+                continue;
+
+            echo "Adding barcode for location " . $location[0] . " \n";
+            $locationBarcodeData = [
+                "locationsBarcodes_value" => "L" . $location[0],
+                "locationsBarcodes_type" => "QR_CODE",
+                "locations_id" => $location[0],
+                "locationsBarcodes_added" => date("Y-m-d H:i:s")
+            ];
+
+            $table = $this->table('locationsBarcodes');
+            $table->insert($locationBarcodeData)
+                ->saveData();
+        }
+    }
+}

--- a/src/api/assets/editAsset.php
+++ b/src/api/assets/editAsset.php
@@ -40,7 +40,7 @@ if (isset($array['assets_tag']) and $array['assets_tag'] != $asset['assets_tag']
 
 $DBLIB->where("assets_id", $array['assets_id']);
 $DBLIB->where("assets.instances_id",$AUTH->data['instance']["instances_id"]);
-$result = $DBLIB->update("assets", array_intersect_key( $array, array_flip( ['assets_linkedTo','assetTypes_id','assets_notes','assets_tag','asset_definableFields_1','asset_definableFields_2','asset_definableFields_3','asset_definableFields_4','asset_definableFields_5','asset_definableFields_6','asset_definableFields_7','asset_definableFields_8','asset_definableFields_9','asset_definableFields_10','assets_value','assets_dayRate','assets_weekRate','assets_mass'] ) ));
+$result = $DBLIB->update("assets", array_intersect_key($array, array_flip(['assets_linkedTo', 'assetTypes_id', 'assets_notes', 'assets_tag', 'asset_definableFields_1', 'asset_definableFields_2', 'asset_definableFields_3', 'asset_definableFields_4', 'asset_definableFields_5', 'asset_definableFields_6', 'asset_definableFields_7', 'asset_definableFields_8', 'asset_definableFields_9', 'asset_definableFields_10', 'assets_value', 'assets_dayRate', 'assets_weekRate', 'assets_mass', 'assets_storageLocation'])));
 if (!$result) finish(false, ["code" => "UPDATE-FAIL", "message"=> "Could not update asset"]);
 else {
     $DBLIB->where("assets_id",$array['assets_id']);
@@ -234,6 +234,11 @@ Requires Instance Permission ASSETS:EDIT
  *             ),
  *             @OA\Property(
  *                 property="asset_definableFields_10", 
+ *                 type="string", 
+ *                 description="undefined",
+ *             ),
+ *              @OA\Property(
+ *                 property="assets_storageLocation", 
  *                 type="string", 
  *                 description="undefined",
  *             ),

--- a/src/api/locations/new.php
+++ b/src/api/locations/new.php
@@ -14,6 +14,15 @@ $array['instances_id'] = $AUTH->data['instance']['instances_id'];
 $location = $DBLIB->insert("locations", $array);
 if (!$location) finish(false);
 
+$locationBarcodeData = [
+    "locationsBarcodes_value" => "L" . $location,
+    "locationsBarcodes_type" => "QR_CODE",
+    "locations_id" => $location,
+    "users_userid" => $AUTH->data['users_userid'],
+    "locationsBarcodes_added" => date("Y-m-d H:i:s")
+];
+$locationBarcode = $DBLIB->insert("locationsBarcodes", $locationBarcodeData);
+
 $bCMS->auditLog("INSERT", "locations", json_encode($array), $AUTH->data['users_userid']);
 finish(true);
 

--- a/src/asset.php
+++ b/src/asset.php
@@ -56,7 +56,16 @@ foreach ($assets as $asset) {
     $DBLIB->where("projects.projects_deleted", 0);
     $asset['assignments'] = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.projects_id", "projects.projects_name", "projects_dates_deliver_start", "projects_dates_deliver_end", "assetsAssignments.assetsAssignmentsStatus_id", "projectsStatuses.projectsStatuses_name", "projectsStatuses.projectsStatuses_foregroundColour", "projectsStatuses.projectsStatuses_backgroundColour"]);
 
+    //Files
     $asset['files'] = $bCMS->s3List(4, $asset['assets_id']);
+
+    //Storage Location
+    $DBLIB->where('locations_id', $asset['assets_storageLocation']);
+    $DBLIB->where('instances_id', $AUTH->data['instance']['instances_id']);
+    $DBLIB->where('locations_deleted', 0);
+    $DBLIB->where('locations_archived', 0);
+    $asset['storage_location'] = $DBLIB->get('locations', 1, ['locations_id', 'locations_name']);
+
 
     $PAGEDATA['assets'][] = $asset;
 }
@@ -174,7 +183,7 @@ if (count($PAGEDATA['assets']) == 1) {
     $DBLIB->orderBy("locations_subOf", "ASC");
     $DBLIB->orderBy("locations.locations_name", "ASC");
     $DBLIB->join('locationsBarcodes', 'locationsBarcodes.locations_id=locations.locations_id');
-    $locations = $DBLIB->get("locations", null, ['locationsBarcodes.locationsBarcodes_id', 'locations.locations_name']);
+    $locations = $DBLIB->get("locations", null, ['locationsBarcodes.locationsBarcodes_id', 'locations.locations_id', 'locations.locations_name']);
 
     function linkedLocations($locationId, $tier, $locationKey)
     {
@@ -185,7 +194,7 @@ if (count($PAGEDATA['assets']) == 1) {
         $DBLIB->where("locations.locations_deleted", 0);
         $DBLIB->where("locations.locations_archived", 0);
         $DBLIB->join('locationsBarcodes', 'locationsBarcodes.locations_id=locations.locations_id');
-        $locations = $DBLIB->get("locations", null, ['locationsBarcodes.locationsBarcodes_id', 'locations.locations_name']);
+        $locations = $DBLIB->get("locations", null, ['locationsBarcodes.locationsBarcodes_id', 'locations.locations_id', 'locations.locations_name']);
         $tier += 1;
         foreach ($locations as $location) {
             $location['tier'] = $tier;

--- a/src/asset.twig
+++ b/src/asset.twig
@@ -295,7 +295,6 @@
                                                                 <option value="" disabled selected>No Location Selected....</option>
                                                             {% endif %}
                                                             {% for location in locations %}
-                                                                <script>console.log('{{ location.location_id }}')</script>
                                                                 <option value="{{ location.locations_id }}" {{ assets[0]['storage_location'][0]['locations_id'] == location.locations_id ? 'selected' }} {{ location.locations_archived == 1 ? 'disabled' }}>{{ location.locations_archived == 1 ? '[Archived] ' }}{{ location.locations_name }}</option>
                                                                 {% for subLocation in location.linkedToThis %}
                                                                     <option value="{{ subLocation.locations_id }}" {{ assets[0]['storage_location'][0]['locations_id'] == subLocation.locations_id ? 'selected' }}  {{ subLocation.locations_archived == 1 ? 'disabled' }} title="{% for i in range(1, subLocation['tier']) %}{% if loop.last %}&#8627;{% else %}&nbsp;&nbsp;{% endif %}{% endfor %}">

--- a/src/asset.twig
+++ b/src/asset.twig
@@ -39,22 +39,32 @@
                                 {% if field != "" %}
                                     {% set assetFieldsLength = assetFieldsLength +1 %}{# Build a count of the number of fields use to help editing an asset #}
                                     <li class="list-group-item">
-                                        <b>{{field}}</b> <a class="float-right">{{ assets[0]['asset_definableFields_' ~ loop.index] }}</a>
+                                        <b>{{field}}</b> <span class="float-right text-primary">{{ assets[0]['asset_definableFields_' ~ loop.index] }}</span>
                                     </li>
                                 {% endif %}
                             {% endfor %}
                             <li class="list-group-item">
-                                <b>Mass</b> <a class="float-right">{{ (assets[0]['assets_mass'] ? assets[0]['assets_mass']|mass : (asset.assetTypes_mass != "" and asset.assetTypes_mass != 0 ? asset.assetTypes_mass|mass : '?')) }}</a>
+                                <b>Mass</b> <span class="float-right text-primary">{{ (assets[0]['assets_mass'] ? assets[0]['assets_mass']|mass : (asset.assetTypes_mass != "" and asset.assetTypes_mass != 0 ? asset.assetTypes_mass|mass : '?')) }}</span>
                             </li>
                             <li class="list-group-item">
-                                <b>Value</b> <a class="float-right">{{ (assets[0]['assets_value'] ?: asset.assetTypes_value)|money(ASSET_INSTANCE['instances_config_currency']) }}</a>
+                                <b>Value</b> <span class="float-right text-primary">{{ (assets[0]['assets_value'] ?: asset.assetTypes_value)|money(ASSET_INSTANCE['instances_config_currency']) }}</span>
                             </li>
                             <li class="list-group-item">
-                                <b>Day Rate</b> <a class="float-right">{{ (assets[0]['assets_dayRate'] ?: asset.assetTypes_dayRate)|money(ASSET_INSTANCE['instances_config_currency']) }}</a>
+                                <b>Day Rate</b> <span class="float-right text-primary">{{ (assets[0]['assets_dayRate'] ?: asset.assetTypes_dayRate)|money(ASSET_INSTANCE['instances_config_currency']) }}</span>
                             </li>
                             <li class="list-group-item">
-                                <b>Week Rate</b> <a class="float-right">{{ (assets[0]['assets_weekRate'] ?: asset.assetTypes_weekRate)|money(ASSET_INSTANCE['instances_config_currency']) }}</a>
+                                <b>Week Rate</b> <span class="float-right text-primary">{{ (assets[0]['assets_weekRate'] ?: asset.assetTypes_weekRate)|money(ASSET_INSTANCE['instances_config_currency']) }}</span>
                             </li>
+                            {% if assets[0]['storage_location'] %}
+                            <li class="list-group-item">
+                                <b>Storage Location</b>
+                                {% if "LOCATIONS:VIEW"|instancePermissions %}
+                                    <a class="float-right" href="{{ CONFIG.ROOTURL }}/location/">{{assets[0]['storage_location'][0]['locations_name']}}</a>
+                                {% else %}
+                                    <span class="float-right">{{assets[0]['storage_location'][0]['locations_name']}}</span
+                                {% endif %}
+                            </li>
+                            {% endif %}
                         </ul>
                         {% if "ASSETS:ARCHIVE"|instancePermissions and (assets[0].assets_endDate is null or assets[0].assets_endDate|date("U") > "now"|date("U"))  and ASSET_INSTANCE.instances_id == USERDATA.instance.instances_id  %}
                         <button class="btn btn-warning btn-block archiveAssetButton" data-assetid="{{ assets[0]['assets_id'] }}" style="margin-bottom: 10px;">Archive</button>
@@ -65,7 +75,7 @@
                     </div>
                 </div>
             {% endif %}
-            <div class="card card-outline">
+            <div class="card card-info card-outline">
                 <div class="card-body box-profile">
                     {% if CONFIG.FILES_ENABLED == "Enabled" and USERDATA.instance.instances_storageEnabled == 1 and asset.thumbnail %}
                     <div class="text-center {{ asset.thumbnail|length > 1 ? 'slick' : '' }}">
@@ -80,7 +90,7 @@
                     </div>
                     {% endif %}
                     <h3 class="profile-username text-center">{{asset.assetTypes_name}}</h3>
-
+                    <p>{{asset.assetTypes_description|nl2br}}</p>
                     <ul class="list-group list-group-unbordered mb-3">
                         {% if asset.assetTypes_productLink != null %}
                         <li class="list-group-item">
@@ -94,22 +104,22 @@
                             <b>Manufacturer</b> {{ asset.manufacturers_name }}
                         </li>
                         <li class="list-group-item">
-                            <b>Mass</b> <a class="float-right">{{asset.assetTypes_mass != "" and asset.assetTypes_mass != 0 ? asset.assetTypes_mass|mass : "?" }}</a>
+                            <b>Mass</b> <span class="float-right text-primary">{{asset.assetTypes_mass != "" and asset.assetTypes_mass != 0 ? asset.assetTypes_mass|mass : "?" }}</span>
                         </li>
                         <li class="list-group-item">
-                            <b>Value</b> <a class="float-right">{{ asset.assetTypes_value|money(ASSET_INSTANCE['instances_config_currency']) }}</a>
+                            <b>Value</b> <span class="float-right text-primary">{{ asset.assetTypes_value|money(ASSET_INSTANCE['instances_config_currency']) }}</span>
                         </li>
                         <li class="list-group-item">
-                            <b>Day Rate</b> <a class="float-right">{{ asset.assetTypes_dayRate|money(ASSET_INSTANCE['instances_config_currency']) }}</a>
+                            <b>Day Rate</b> <span class="float-right text-primary">{{ asset.assetTypes_dayRate|money(ASSET_INSTANCE['instances_config_currency']) }}</span>
                         </li>
                         <li class="list-group-item">
-                            <b>Week Rate</b> <a class="float-right">{{ asset.assetTypes_weekRate|money(ASSET_INSTANCE['instances_config_currency']) }}</a>
+                            <b>Week Rate</b> <span class="float-right text-primary">{{ asset.assetTypes_weekRate|money(ASSET_INSTANCE['instances_config_currency']) }}</span>
                         </li>
                     </ul>
                     {% if asset.oneasset %}
                         <a href="?id={{asset.assetTypes_id}}" class="btn btn-info btn-block"><b>View All</b></a>
                     {% endif %}
-                    <p>{{asset.assetTypes_description|nl2br}}</p>
+                    
                 </div>
             </div>
         </div>
@@ -275,6 +285,25 @@
                                                     <div class="input-group">
                                                         <div class="input-group-prepend"><span class="input-group-text">Asset Notes</span></div>
                                                         <textarea class="form-control" rows="2" name="assets_notes" placeholder="">{{ assets[0]['assets_notes'] }}</textarea>
+                                                    </div>
+                                                    <div class="input-group">
+                                                        <div class="input-group-prepend">
+                                                            <span class="input-group-text">Storage Location</span>
+                                                        </div>
+                                                        <select class="form-control select2bs4" name="assets_storageLocation" id="editAssetStoredLocation">
+                                                            {% if assets[0]['storage_location'] == [] %}
+                                                                <option value="" disabled selected>No Location Selected....</option>
+                                                            {% endif %}
+                                                            {% for location in locations %}
+                                                                <script>console.log('{{ location.location_id }}')</script>
+                                                                <option value="{{ location.locations_id }}" {{ assets[0]['storage_location'][0]['locations_id'] == location.locations_id ? 'selected' }} {{ location.locations_archived == 1 ? 'disabled' }}>{{ location.locations_archived == 1 ? '[Archived] ' }}{{ location.locations_name }}</option>
+                                                                {% for subLocation in location.linkedToThis %}
+                                                                    <option value="{{ subLocation.locations_id }}" {{ assets[0]['storage_location'][0]['locations_id'] == subLocation.locations_id ? 'selected' }}  {{ subLocation.locations_archived == 1 ? 'disabled' }} title="{% for i in range(1, subLocation['tier']) %}{% if loop.last %}&#8627;{% else %}&nbsp;&nbsp;{% endif %}{% endfor %}">
+                                                                        {{ subLocation.locations_archived == 1 ? '[Archived] ' }}{{ subLocation.locations_name }}
+                                                                    </option>
+                                                                {% endfor %}
+                                                            {% endfor %}
+                                                        </select>
                                                     </div>
                                                 </form>
                                                 <button class="btn btn-default float-right" id="saveAssetSettingsButton" style="margin-top:10px;margin-bottom:10px;">Save</button>
@@ -475,10 +504,10 @@
                             <div class="callout callout-info m-2">
                                 <p>Use the buttons below to set the location of this asset without scanning a barcode.</p>
                             </div>
-                            <div class="btn-group">
-                                <button class="btn btn-info m-2" id="setAssetLocationButton">Manually pick location from list</button>
-                                <button class="btn btn-info m-2" id="setAssetLocationAssetButton">Manually set location to be within another Asset</button>
-                                <button class="btn btn-info m-2" id="setCustomLocationButton">Manually set Custom Location</button>
+                            <div class="btn-group m-2">
+                                <button class="btn btn-info" id="setAssetLocationButton">Manually pick location from list</button>
+                                <button class="btn btn-info" id="setAssetLocationAssetButton">Manually set location to be within another Asset</button>
+                                <button class="btn btn-info" id="setCustomLocationButton">Manually set Custom Location</button>
                             </div>
                             {% endif %}
                         </div>
@@ -841,7 +870,7 @@
                 </div><!-- /.card-body -->
             </div>
             {% endif %}
-            <div class="card">
+            <div class="card card-info card-outline">
                 <div class="card-header p-2">
                     <ul class="nav nav-pills">
                         {% if asset.oneasset %}
@@ -2170,6 +2199,24 @@
                     ajaxcall('assets/barcodes/search.php', args, () => {location.reload()});
                 });
                 {% endif %} 
+                {% if "LOCATIONS:VIEW"|instancePermissions %}
+                $('#editAssetStoredLocation').select2({
+                    tags: false,
+                    multiple: false,
+                    theme: "bootstrap4",
+                    minimumInputLength: 0,
+                    minimumResultsForSearch: 1,
+                    templateResult: function (input) {
+                        if (!input.id || !input.title) {
+                            return input.text;
+                        }
+                        var $result = $(
+                            '<span><b>' + input.title + ' </b>' + input.text + '</span>'
+                        );
+                        return $result;
+                    }
+                });
+                {% endif %}
             });
         </script>
 {% embed 'assets/templates/fileBoxJS.twig' %}

--- a/src/location/barcode.php
+++ b/src/location/barcode.php
@@ -13,18 +13,7 @@ if (!$PAGEDATA['location']) die($TWIG->render('404.twig', $PAGEDATA));
 $DBLIB->where("locations_id",$PAGEDATA['location']['locations_id']);
 $DBLIB->where("locationsBarcodes_deleted",0);
 $PAGEDATA['barcode'] = $DBLIB->getone("locationsBarcodes");
-if (!$PAGEDATA['barcode']) {
-    $locationBarcodeData = [
-        "locationsBarcodes_value" => "L" . $PAGEDATA['location']['locations_id'],
-        "locationsBarcodes_type" => "QR_CODE",
-        "locations_id" => $PAGEDATA['location']['locations_id'],
-        "users_userid" => $AUTH->data['users_userid'],
-        "locationsBarcodes_added" => date("Y-m-d H:i:s")
-    ];
-    $insert = $DBLIB->insert("locationsBarcodes", $locationBarcodeData);
-    $locationBarcodeData['locationsBarcodes_id'] = $insert;
-    $PAGEDATA['barcode'] = $locationBarcodeData;
-}
+if (!$PAGEDATA['barcode']) die($TWIG->render('404.twig', $PAGEDATA));
 
 echo $TWIG->render('location/location_barcode.twig', $PAGEDATA);
 ?>


### PR DESCRIPTION
### Description
Adds storage locations to assets, as a standalone field to assignment location handling
Intended to be used to describe where an asset's typical storage location.

Closes #653 

![image](https://github.com/user-attachments/assets/c722ab06-df97-4173-b87c-6979dee6e91b)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [x] I have updated the API documentation for any routes changed, within each api file.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue is linked to this pull request.
