### PR TITLE
Add warning if default username and password is enabled

### DIFF
--- a/src/api/account/isDefaultAccountEnabled.php
+++ b/src/api/account/isDefaultAccountEnabled.php
@@ -1,0 +1,60 @@
+<?php
+require_once __DIR__ . '/../apiHead.php';
+
+$DBLIB->where("users_password", "fa5a51baef12914c7f2e0e1176a030bf086d26edae298c25d5f84c90bc72ecd7");
+$DBLIB->where("users_salty1", "8smqAFD9");
+$DBLIB->where("users_salty2", "uOhfrOCW");
+$DBLIB->where("users_hash", "sha256");
+$DBLIB->where("users_username", "username");
+$count = $DBLIB->getValue("users", "count(*)");
+if ($count > 0) finish(true, null, ["enabled" => true]);
+else finish(true, null, ["enabled" => false]);
+
+/** @OA\Post(
+ *     path="/account/isDefaultAccountEnabled.php", 
+ *     summary="Check if the default account is enabled", 
+ *     description="The default account being enabled poses a security risk, so this endpoint is used to check if it is enabled and to warn users.", 
+ *     operationId="isDefaultAccountEnabled", 
+ *     tags={"account"}, 
+ *     @OA\Response(
+ *         response="200", 
+ *         description="Success",
+ *         @OA\MediaType(
+ *             mediaType="application/json", 
+ *             @OA\Schema( 
+ *                 type="object", 
+ *                 @OA\Property(
+ *                     property="result", 
+ *                     type="boolean", 
+ *                     description="Whether the request was successful",
+ *                 ),
+ *                 @OA\Property(
+ *                     property="response", 
+ *                     type="array", 
+ *                     description="The enabled parameter is true if the default account is enabled, false otherwise",
+ *                 ),
+ *             ),
+ *         ),
+ *     ), 
+ *     @OA\Response(
+ *         response="default", 
+ *         description="Error",
+ *         @OA\MediaType(
+ *             mediaType="application/json", 
+ *             @OA\Schema( 
+ *                 type="object", 
+ *                 @OA\Property(
+ *                     property="result", 
+ *                     type="boolean", 
+ *                     description="Whether the request was successful",
+ *                 ),
+ *                 @OA\Property(
+ *                     property="error", 
+ *                     type="array", 
+ *                     description="An Array containing an error code and a message",
+ *                 ),
+ *             ),
+ *         ),
+ *     ), 
+ * )
+ */

--- a/src/login/login_template.twig
+++ b/src/login/login_template.twig
@@ -133,6 +133,10 @@
 						                            col-xs-10 offset-xs-1">
 					<div id="masterBox">
 						<a href="{{CONFIG.ROOTURL}}/login/?"><img src="{{ CONFIG.ROOTURL}}/static-assets/img/login/logo.svg" style="height:5em; margin-bottom: 15px; margin-top: 10px;" id="bCMSLogoHeader"/></a>
+						<div class="alert alert-danger" style="border: 0px; text-align: left; display: none;" id="defaultAccountEnabledWarning">
+							<h4>The default super administrator account for {{ CONFIG.PROJECT_NAME }} is enabled</h4>
+							<p>Login to this account and change the password. Default username is <strong>username</strong> and password is <strong>password!</strong></p>
+						</div>
 						{% if CONFIG.DEV %}
 							<div class="alert alert-warning" style="border: 0px; text-align: left;">
 								<h4>{{ CONFIG.PROJECT_NAME }} is running in development mode, and should only be used for testing purposes</h4>
@@ -160,6 +164,22 @@
 				</div>
 			</div>
 		</div>
+		<script>
+			$(document).ready(function () {
+				$.ajax({
+						url: "../api/account/isDefaultAccountEnabled.php",
+						type: "GET",
+						dataType: 'json',
+						success: function(result) {
+								if (result.result) {
+										if (result.response.enabled) {
+												$("#defaultAccountEnabledWarning").show();
+										}
+								}
+						}
+				});
+			});
+		</script>
 		{{ CONFIG.FOOTER_ANALYTICS|raw }}
 	</body>
 </html>


### PR DESCRIPTION
This pull request introduces a new feature to check if the default account is enabled and display a warning message on the login page if it is. The main changes include adding a new API endpoint, modifying the login template to include a warning message, and adding a script to call the new API endpoint.

<img width="749" alt="Screenshot 2025-03-02 at 11 27 36 am" src="https://github.com/user-attachments/assets/3d1fc349-be16-4726-8120-4935b6a92d8d" />
