### PR TITLE
787-fixed-darkmode-issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor/
 /s3files/
 
 **/.idea
+.qodo

--- a/src/assets.twig
+++ b/src/assets.twig
@@ -183,7 +183,7 @@
                 <div class="row d-flex align-items-stretch">
                     {% for asset in searchResults.ASSETS %}
                         <div class="col-auto d-flex align-items-stretch" style="padding: 10px;">
-                            <div class="card bg-light">
+                            <div class="card">
                                 <div class="card-body" style="max-width: 250px;">
                                     <h2 class="lead"><b>{{ asset.assetTypes_name }}</b></h2>
                                     {% if CONFIG.FILES_ENABLED == "Enabled" and USERDATA.instance.instances_storageEnabled == 1 and asset.thumbnail|length > 0 and searchResults.SEARCH.SETTINGS.HIDEIMAGES != true %}

--- a/src/static-assets/css/adminlte.css
+++ b/src/static-assets/css/adminlte.css
@@ -31689,6 +31689,7 @@ html.maximized-card {
 
 .dark-mode .modal-content {
   background-color: #343a40;
+  color: #ffffff;
 }
 
 .dark-mode .modal-content.bg-warning .modal-header,


### PR DESCRIPTION
### Description

I fixed the issue #787 where the text in the add new assets to project popup wasnt nicely readeble (old screenshot in issue):
![grafik](https://github.com/user-attachments/assets/6d18ee7c-e135-4156-874e-027734b72d95)




### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [ ] I have updated the API documentation for any routes changed, within each api file.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue is linked to this pull request.
