### PR TITLE
Add support for TLS encryption in SMTP, to allow SES support

### DIFF
--- a/src/common/libs/Config/configStructureArray.php
+++ b/src/common/libs/Config/configStructureArray.php
@@ -235,6 +235,27 @@ $configStructureArray = [
     "default" => 465,
     "envFallback" => "CONFIG_EMAILS_SMTP_PORT",
   ],
+  "EMAILS_SMTP_ENCRYPTION" => [
+    "form" => [
+      "type" => "select",
+      "default" => function () {
+        return "SSL";
+      },
+      "name" => "SMTP encryption type",
+      "group" => "Email",
+      "description" => "If SMTP is selected above, the encryption type to use when connecting to the SMTP server",
+      "required" => false,
+      "maxlength" => 255,
+      "minlength" => 0,
+      "options" => ["None", "SSL", "TLS"],
+      "verifyMatch" => function ($value, $options) {
+        return ["valid" => in_array($value, $options), "value" => $value, "error" => in_array($value, $options) ? '' : "Invalid option selected"];
+      }
+    ],
+    "specialRequest" => true,
+    "default" => "SSL",
+    "envFallback" => false,
+  ],
   "EMAILS_FOOTER" => [
     "form" => [
       "type" => "text",

--- a/src/common/libs/Email/SMTPHandler.php
+++ b/src/common/libs/Email/SMTPHandler.php
@@ -27,9 +27,17 @@ class SMTPEmailHandler extends EmailHandler
         $mail->SMTPAuth = true;
         $mail->Username = $CONFIGCLASS->get('EMAILS_SMTP_USERNAME');
         $mail->Password = $CONFIGCLASS->get('EMAILS_SMTP_PASSWORD');
-        $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
       } else {
         $mail->SMTPAuth = false;
+      }
+
+      $encryptionType = $CONFIGCLASS->get('EMAILS_SMTP_ENCRYPTION');
+      if ($encryptionType === 'None') {
+        $mail->SMTPSecure = false;
+      } elseif ($encryptionType === 'TLS') {
+        $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+      } else {
+        $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS; // Default to SMTPS for backward compatibility
       }
 
       //Recipients


### PR DESCRIPTION
This pull request introduces support for selecting the SMTP encryption type in the email configuration, adding flexibility and improving compatibility with various SMTP servers. The most important changes include adding a new configuration option for encryption type and updating the email sending logic to respect this configuration.

### Configuration Enhancements:
* [`src/common/libs/Config/configStructureArray.php`](diffhunk://#diff-a4e8fb79917239a932b55912556cb3ca2d29c37d2fe65aeed733772289a1f1eeR238-R258): Added a new configuration option `EMAILS_SMTP_ENCRYPTION` to allow users to select the SMTP encryption type (`None`, `SSL`, or `TLS`). Includes validation logic to ensure a valid selection and a default value of `SSL`.

### Email Sending Logic Updates:
* [`src/common/libs/Email/SMTPHandler.php`](diffhunk://#diff-22333f91eefef68717cf6e02da052525c49975d693d1abf8f8051e882de3829cL30-R42): Updated the `sendEmail` function to dynamically set the `$mail->SMTPSecure` property based on the `EMAILS_SMTP_ENCRYPTION` configuration. Defaults to `SMTPS` for backward compatibility if no valid encryption type is specified.