### PR TITLE
Add asset definable fields to asset search

### DIFF
--- a/src/api/assets/searchAssets.php
+++ b/src/api/assets/searchAssets.php
@@ -31,7 +31,6 @@ $assets = $DBLIB->get("assets", 15, [
 	"assets.asset_definableFields_9",
 	"assets.asset_definableFields_10",
 	"assetTypes.assetTypes_definableFields",
-	"assetTypes.assetTypes_definableFields_ARRAY",
 	"assetTypes.assetTypes_name",
 	"assetTypes.assetTypes_id",
 	"assetCategories.assetCategories_name",


### PR DESCRIPTION
### Description
Adds asset definable fields (Length, Fuse, etc.) to `/api/assets/searchAssets.php`. 
This adds almost no overhead to the `searchAssets.php` call.
There is no way to obtain this data other than to add an asset to a Project and query the data given from `/api/projects/assets/statusList.php`, which is more intensive for both client and server. 


### Checklist

- [x] I accept the contributor license agreement for this repository.
- [ ] I have added documentation for new/changed functionality in this PR or in the 
[documentation repo](https://github.com/adam-rms/website).
- [ ] I have updated the API documentation for any routes changed, within each api file.
    - N/A, is covered by current documentation
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [ ] A GitHub issue is linked to this pull request.
