### PR TITLE
draft: Add optional grouping of linked Assets in Project asset dispatch View

### DIFF
--- a/src/project/project_assetsBoard.twig
+++ b/src/project/project_assetsBoard.twig
@@ -44,6 +44,17 @@
                         <i class="fas fas fa-shipping-fast"></i>
                     </button>
                 </li>
+                <li class="nav-item">
+                    {% if BOARDGROUPED %}
+                        <a class="nav-link btn" href="?id={{ project.projects_id }}&ungrouped" onclick="this.href+=window.location.hash" title="Grouped - Click to ungroup linked assets">
+                            <i class="fas fa-layer-group"></i>
+                        </a>
+                    {% else %}
+                        <a class="nav-link btn" href="?id={{ project.projects_id }}" onclick="this.href+=window.location.hash" title="Ungrouped - Click to group linked assets">
+                            <i class="fas fa-list"></i>
+                        </a>
+                    {% endif %}
+                </li>
             {% endif %}
         </ul>
     </div>
@@ -190,6 +201,27 @@
             });
         });
     }
+    
+    /**
+     * Function to change status of a parent asset and all its children
+     * @param parentAssignment Id of the parent AssetAssignment
+     * @param childAssignments Comma-separated string of child AssetAssignment IDs
+     * @param newStatus New status id
+     */
+    function changeStatusWithChildren(parentAssignment, childAssignments, newStatus) {
+        // Update parent assignment
+        changeStatus(parseInt(parentAssignment), parseInt(newStatus));
+        
+        // Update all child assignments if any
+        if (childAssignments && childAssignments.toString().length > 0) {
+            const childIds = childAssignments.toString().split(',');
+            childIds.forEach(function(childId) {
+                if (childId && !isNaN(parseInt(childId))) {
+                    changeStatus(parseInt(childId), parseInt(newStatus));
+                }
+            });
+        }
+    }
     {% endif %}
     $(document).ready(function () {
         {% if "PROJECTS:PROJECT_ASSETS:EDIT:ASSIGNMENT_STATUS"|instancePermissions %}
@@ -206,19 +238,23 @@
                 const groupStatus = this.dataset.statusid;
                 const assetOldStatus = ui.item[0].dataset.currentstatus;
                 const assetAssignment = ui.item[0].dataset.assignment;
+                const childAssignments = ui.item[0].dataset.childAssignments;
 
                 if (assetOldStatus !== groupStatus) {
-                    changeStatus(parseInt(assetAssignment),parseInt(groupStatus));
+                    changeStatusWithChildren(assetAssignment, childAssignments, groupStatus);
                     ui.item[0].dataset.currentstatus = groupStatus;
                 }
             }
         });
 
         $(".assetDispatchAssetList-statusPrevButton,.assetDispatchAssetList-statusNextButton").click(function (){
-            const assetCard = $(this).parent();
+            const assetCard = $(this).closest('.assetDispatchAssetList-card');
             const assetAssignment = assetCard.data("assignment");
+            const childAssignments = assetCard.data("child-assignments");
             const assetNextStatus = $(this).data("nextstatus");
-            changeStatus(parseInt(assetAssignment),parseInt(assetNextStatus));
+            
+            changeStatusWithChildren(assetAssignment, childAssignments, assetNextStatus);
+            
             //move card to new status
             assetCard.detach().appendTo(".assetDispatchAssetList[data-statusid=" + assetNextStatus + "][data-instance=" + assetCard.data("instance") + "]");
         });

--- a/src/project/project_assetsBoard.twig
+++ b/src/project/project_assetsBoard.twig
@@ -18,10 +18,10 @@
             max-width: 100%;
         }
     }
-    #navItemQuickDispatch {
+    .extended-functions {
         height: 100%;
     }
-    #navItemQuickDispatch button {
+    .extended-functions button {
         background-color: transparent;
     }
 </style>
@@ -39,20 +39,20 @@
                 </li>
             {% endfor %}
             {% if (FINANCIALS.assetsAssigned|length > 0 or FINANCIALS.assetsAssignedSUB|length > 0) and "PROJECTS:PROJECT_ASSETS:EDIT:ASSIGNMENT_STATUS"|instancePermissions %}
-                <li class="nav-item" id="navItemQuickDispatch">
+                <li class="nav-item extended-functions">
                     <button type="button" class="nav-link" title="Quick Dispatch" data-toggle="modal" data-target="#quickDispatchModal">
-                        <i class="fas fas fa-shipping-fast"></i>
+                        <i class="fas fa-shipping-fast"></i>
                     </button>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item extended-functions">
                     {% if BOARDGROUPED %}
-                        <a class="nav-link btn" href="?id={{ project.projects_id }}&ungrouped" onclick="this.href+=window.location.hash" title="Grouped - Click to ungroup linked assets">
+                        <button type="button" class="nav-link grouping-toggle" data-href="?id={{ project.projects_id }}&ungrouped" title="Grouped - Click to ungroup linked assets" aria-label="Toggle asset grouping">
                             <i class="fas fa-layer-group"></i>
-                        </a>
+                        </button>
                     {% else %}
-                        <a class="nav-link btn" href="?id={{ project.projects_id }}" onclick="this.href+=window.location.hash" title="Ungrouped - Click to group linked assets">
+                        <button type="button" class="nav-link grouping-toggle" data-href="?id={{ project.projects_id }}" title="Ungrouped - Click to group linked assets" aria-label="Toggle asset grouping">
                             <i class="fas fa-list"></i>
-                        </a>
+                        </button>
                     {% endif %}
                 </li>
             {% endif %}
@@ -189,7 +189,7 @@
     }
     /**
      * Function to change the status of an asset assignment
-     * @param assetsAssignments_id Id of the AssetAssignment
+     * @param assetsAssignments_id Id of the AssetAssignment (single ID or array of IDs)
      * @param assetsAssignments_status new status id of the AssetAssignment
      */
     function changeStatus(assetsAssignments_id, assetsAssignments_status) {
@@ -203,24 +203,24 @@
     }
     
     /**
-     * Function to change status of a parent asset and all its children
+     * Function to change status of a parent asset and all its children in a single API call
      * @param parentAssignment Id of the parent AssetAssignment
      * @param childAssignments Comma-separated string of child AssetAssignment IDs
      * @param newStatus New status id
      */
     function changeStatusWithChildren(parentAssignment, childAssignments, newStatus) {
-        // Update parent assignment
-        changeStatus(parseInt(parentAssignment), parseInt(newStatus));
+        // Collect all assignment IDs (parent + children)
+        const allIds = [parseInt(parentAssignment)];
         
-        // Update all child assignments if any
         if (childAssignments && childAssignments.toString().length > 0) {
             const childIds = childAssignments.toString().split(',');
             childIds.forEach(function(childId) {
                 if (childId && !isNaN(parseInt(childId))) {
-                    changeStatus(parseInt(childId), parseInt(newStatus));
+                    allIds.push(parseInt(childId));
                 }
             });
         }
+        changeStatus(allIds, parseInt(newStatus));
     }
     {% endif %}
     $(document).ready(function () {
@@ -250,13 +250,14 @@
         $(".assetDispatchAssetList-statusPrevButton,.assetDispatchAssetList-statusNextButton").click(function (){
             const assetCard = $(this).closest('.assetDispatchAssetList-card');
             const assetAssignment = assetCard.data("assignment");
-            const childAssignments = assetCard.data("child-assignments");
+            const childAssignments = assetCard.data("childAssignments");
             const assetNextStatus = $(this).data("nextstatus");
             
             changeStatusWithChildren(assetAssignment, childAssignments, assetNextStatus);
             
             //move card to new status
             assetCard.detach().appendTo(".assetDispatchAssetList[data-statusid=" + assetNextStatus + "][data-instance=" + assetCard.data("instance") + "]");
+            drawButtons();
         });
 
         function doQuickDispatch() {
@@ -311,6 +312,11 @@
 
         $('a.assetsBoardToggle[data-toggle="pill"]').on('click', function (e) {
             localStorage.setItem("activeTab-board", e.target.getAttribute('aria-controls'));
-        })
+        });
+
+        // Preserve URL hash when toggling grouping mode
+        $('button.grouping-toggle').on('click', function (e) {
+            window.location.href = $(this).data('href') + window.location.hash;
+        });
     });
 </script>

--- a/src/project/twigIncludes/assetBoard/board.twig
+++ b/src/project/twigIncludes/assetBoard/board.twig
@@ -1,14 +1,17 @@
-{# Macro to render children recursively #}
-{% macro renderChildren(children, instanceid, depth) %}
-    {% import _self as self %}
-    {% for child in children %}
-        <div class="row align-middle p-2 m-0 border-top border-secondary" data-assignment="{{ child['assetsAssignments_id'] }}" data-asset="{{ child['assets_id'] }}" data-parent="{{ child['assets_linkedTo'] }}">
-            <h6 class="col my-auto" style="padding-left: {{ (depth * 1.5) + 0.5 }}rem;"><small class="text-muted">↳</small> <i>(<a target="_blank" href="{{ CONFIG.ROOTURL }}/asset.php?id={{ child['assetTypes_id'] }}&asset={{ child['assets_id'] }}&instance={{ instanceid }}">{{ child['assets_tag'] }}</a>)</i><br><small style="padding-left: {{ (depth * 1.5) + 0.5 }}rem;">{{ child['assetTypes_name'] }}</small></h6>
-        </div>
-        {% if child.children|default([])|length > 0 %}
-            {{ self.renderChildren(child.children, instanceid, depth + 1) }}
-        {% endif %}
-    {% endfor %}
+{# Macro to render children recursively (max depth: 10 to prevent infinite recursion) #}
+{% macro renderChildren(children, instanceid, depth, maxDepth) %}
+    {% set maxDepth = maxDepth|default(10) %}
+    {% if depth <= maxDepth %}
+        {% import _self as self %}
+        {% for child in children %}
+            <div class="row align-middle p-2 m-0 border-top border-secondary" data-assignment="{{ child['assetsAssignments_id'] }}" data-asset="{{ child['assets_id'] }}" data-parent="{{ child['assets_linkedTo'] }}">
+                <h6 class="col my-auto" style="padding-left: {{ (depth * 1.5) + 0.5 }}rem;"><small class="text-muted">↳</small> <i>(<a target="_blank" href="{{ CONFIG.ROOTURL }}/asset.php?id={{ child['assetTypes_id'] }}&asset={{ child['assets_id'] }}&instance={{ instanceid }}">{{ child['assets_tag'] }}</a>)</i><br><small style="padding-left: {{ (depth * 1.5) + 0.5 }}rem;">{{ child['assetTypes_name'] }}</small></h6>
+            </div>
+            {% if child.children|default([])|length > 0 %}
+                {{ self.renderChildren(child.children, instanceid, depth + 1, maxDepth) }}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
 {% endmacro %}
 {% import _self as macros %}
 

--- a/src/project/twigIncludes/assetBoard/board.twig
+++ b/src/project/twigIncludes/assetBoard/board.twig
@@ -1,3 +1,17 @@
+{# Macro to render children recursively #}
+{% macro renderChildren(children, instanceid, depth) %}
+    {% import _self as self %}
+    {% for child in children %}
+        <div class="row align-middle p-2 m-0 border-top border-secondary" data-assignment="{{ child['assetsAssignments_id'] }}" data-asset="{{ child['assets_id'] }}" data-parent="{{ child['assets_linkedTo'] }}">
+            <h6 class="col my-auto" style="padding-left: {{ (depth * 1.5) + 0.5 }}rem;"><small class="text-muted">↳</small> <i>(<a target="_blank" href="{{ CONFIG.ROOTURL }}/asset.php?id={{ child['assetTypes_id'] }}&asset={{ child['assets_id'] }}&instance={{ instanceid }}">{{ child['assets_tag'] }}</a>)</i><br><small style="padding-left: {{ (depth * 1.5) + 0.5 }}rem;">{{ child['assetTypes_name'] }}</small></h6>
+        </div>
+        {% if child.children|default([])|length > 0 %}
+            {{ self.renderChildren(child.children, instanceid, depth + 1) }}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}
+{% import _self as macros %}
+
 <div class="p-2 scrolling-head h-100" >
     {% for status in instanceAssets %}
         {% if status.instances_id == instanceid %}
@@ -8,13 +22,22 @@
                 </div>
                 <div class="card-body assetDispatchAssetList" data-statusid="{{ status['assetsAssignmentsStatus_id'] }}" data-instance="{{ instanceid }}">
                     {% for asset in status['assets'] %}
-                        <div class="row align-middle p-2 border border-secondary border-2 rounded mt-auto mb-2 assetDispatchAssetList-card" data-currentstatus="{{ status['assetsAssignmentsStatus_id'] }}" data-assignment="{{ asset['assetsAssignments_id'] }}" data-instance="{{ instanceid }}" data-asset="{{ asset['assets_id'] }}">
-                            {% if "PROJECTS:PROJECT_ASSETS:EDIT:ASSIGNMENT_STATUS"|instancePermissions%}
-                                <button class="btn btn-outline-secondary assetDispatchAssetList-statusPrevButton col-1" data-nextstatus="" style="display: none;">«</button>
-                            {% endif %}
-                            <h6 class="col my-auto "><i>(<a target="_blank" href="{{ CONFIG.ROOTURL }}/asset.php?id={{ asset['assetTypes_id'] }}&asset={{ asset['assets_id'] }}&instance={{ instanceid }}">{{ asset['assets_tag'] }}</a>)</i><br>{{ asset['assetTypes_name'] }}</h6>
-                            {% if "PROJECTS:PROJECT_ASSETS:EDIT:ASSIGNMENT_STATUS"|instancePermissions%}
-                                <button class="btn btn-outline-secondary assetDispatchAssetList-statusNextButton col-1" data-nextstatus="" style="display: none;">»</button>
+                        <div class="border border-secondary border-2 rounded mt-auto mb-2 assetDispatchAssetList-card overflow-hidden" data-currentstatus="{{ status['assetsAssignmentsStatus_id'] }}" data-assignment="{{ asset['assetsAssignments_id'] }}" data-child-assignments="{{ asset.allChildAssignmentIds|default([])|join(',') }}" data-instance="{{ instanceid }}" data-asset="{{ asset['assets_id'] }}">
+                            {# Main asset row #}
+                            <div class="row align-middle p-2 m-0">
+                                {% if "PROJECTS:PROJECT_ASSETS:EDIT:ASSIGNMENT_STATUS"|instancePermissions%}
+                                    <button class="btn btn-outline-secondary assetDispatchAssetList-statusPrevButton col-1" data-nextstatus="" style="display: none;">«</button>
+                                {% endif %}
+                                <h6 class="col my-auto "><i>(<a target="_blank" href="{{ CONFIG.ROOTURL }}/asset.php?id={{ asset['assetTypes_id'] }}&asset={{ asset['assets_id'] }}&instance={{ instanceid }}">{{ asset['assets_tag'] }}</a>)</i><br>{{ asset['assetTypes_name'] }}</h6>
+                                {% if "PROJECTS:PROJECT_ASSETS:EDIT:ASSIGNMENT_STATUS"|instancePermissions%}
+                                    <button class="btn btn-outline-secondary assetDispatchAssetList-statusNextButton col-1" data-nextstatus="" style="display: none;">»</button>
+                                {% endif %}
+                            </div>
+                            {# Child assets inside the same card (recursive) #}
+                            {% if asset.children|default([])|length > 0 %}
+                                <div class="border-top border-secondary" style="background-color: rgba(0,0,0,0.04);">
+                                    {{ macros.renderChildren(asset.children, instanceid, 1) }}
+                                </div>
                             {% endif %}
                         </div>
                     {% endfor %}


### PR DESCRIPTION
### Description

Added a new feature for grouping Assets in the Asset Dispatch view.
This helps to easier move Assets that are linked together. For example a Case that is packed with 6 Items.
By default this mode is enabled, but you can disable it. This will then be saved as a URL Parameter.

It also works with multi level Assets.

<img width="388" height="431" alt="image" src="https://github.com/user-attachments/assets/9140e01d-7fab-40ae-be7d-741cd8f691d3" />

<img width="374" height="434" alt="image" src="https://github.com/user-attachments/assets/d6d811b0-58e7-445f-a64e-fe2cfe809ea0" />


 
### Known issues :
- [x] When assets are linked in a loop, they don't appear.
          Example: A1 -> A2 -> A3 -> A1
- [x] Icon colour of the Switcher is not correct yet


### Open Questions:
- [ ] Does it make sense to save the Mode of the Grouping in the URL ?
- [ ] In general should it be possible to Link Assets in a loop ? or should this be prevented when linking an Asset ?


### Checklist

- [x] I accept the contributor license agreement for this repository.
- [ ] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [ ] I have updated the API documentation for any routes changed, within each api file.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [ ] A GitHub issue is linked to this pull request.
