### PR TITLE
Add auto submit in the asset Search

### DIFF
--- a/src/assets.twig
+++ b/src/assets.twig
@@ -448,6 +448,11 @@ function replaceQueryParam(param, newval, search) {
     return (query.length > 2 ? query + "&" : "?") + (newval ? param + "=" + newval : '');
 }
 $(document).ready(function () {
+    // Auto-submit when selecting or clearing something in Select2
+    $('#assetSearchForm select').on('select2:select select2:unselect', function(e) {
+        $('#assetSearchForm').submit();
+    });
+
     $('#assetSearchForm input[name ="dates"]').daterangepicker({
         timePicker: true,
         timePickerIncrement: 15,


### PR DESCRIPTION
### Description

When an select property is changed the Search is automatically triggered. This is done by a Javascript .on function.

This helps with a much faster workflow when adding Assets to an Event, since you don't need to hit the button extra to search.
The initial Idea was to allow a Enter to Search, but this event gets blocked by the select element.



### Checklist

- [x] I accept the contributor license agreement for this repository.
- [ ] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [ ] I have updated the API documentation for any routes changed, within each api file.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [ ] A GitHub issue is linked to this pull request.
