### PR TITLE
Fix gray bar appearing over "Nobody has commented" text in project index

### DIFF
--- a/src/project/project_index.twig
+++ b/src/project/project_index.twig
@@ -50,11 +50,6 @@
         .timeline-body > p {
             margin-bottom: 0;
         }
-        
-        /* Hide timeline bar when empty */
-        .timeline-empty::before {
-            content: none !important;
-        }
     </style>
 
     <!--Summernote-->


### PR DESCRIPTION
### Description

This PR fixes a UI bug caused by the comments timeline object being placed over the default "Nobody has commented on this project" text displayed when a project has no comments, manifesting as a gray bar over part of the text:
<img width="450" height="169" alt="image" src="https://github.com/user-attachments/assets/090ca167-03bb-46f2-a073-df2ff9d40475" />
 The default text has been relocated over the timeline object and logic has been modified to ensure that all timeline objects only display when a project has comments:
<img width="336" height="187" alt="image" src="https://github.com/user-attachments/assets/baef4127-6bd8-4978-a453-4b74ad9fded8" />

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [ ] I have added documentation for new/changed functionality in this PR or in the [documentation repo](https://github.com/adam-rms/website).
- [ ] I have updated the API documentation for any routes changed, within each api file.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used (if not `main`).
- [ ] A GitHub issue is linked to this pull request.
