### PR TITLE
Creates a signed build provenance attestation tied to the image digest

### DIFF
--- a/.github/workflows/dockerBuild.yml
+++ b/.github/workflows/dockerBuild.yml
@@ -10,6 +10,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the `dockerBuild.yml` GitHub Actions workflow to enhance security and add image attestation. The most significant changes include adding explicit permissions for the workflow, integrating image attestation after the Docker build, and improving step identification for digest tracking.

* Introduced a new step to attest the Docker image using `actions/attest@v2`, leveraging the image digest and pushing the attestation to the registry for improved supply chain security.