### PR TITLE
Simplify price retrieval by using product default_price

### DIFF
--- a/src/api/instances/billing/getPrices.php
+++ b/src/api/instances/billing/getPrices.php
@@ -15,11 +15,8 @@ use Money\Formatter\IntlMoneyFormatter;
 
 foreach ($products->data as $product) {
   if (!$product->default_price) continue;
-  $thisPrice = $stripe->prices->search([
-    'query' => 'active:\'true\' AND type:\'recurring\' AND product:\'' . $product->id . '\'',
-  ]);
-  if (!$thisPrice->data or count($thisPrice->data) < 1) continue;
-  $priceData = $stripe->prices->retrieve($thisPrice->data[0]->id, ["expand" => ['currency_options']]);
+  $priceData = $stripe->prices->retrieve($product->default_price, ["expand" => ['currency_options']]);
+  if (!$priceData->active || $priceData->type !== 'recurring') continue;
   $productReturn = [
     'id' => $product->id,
     'name' => $product->name,


### PR DESCRIPTION
## Summary
Refactored the price retrieval logic in the billing API to use the product's `default_price` field directly instead of performing a separate search query.

## Key Changes
- Replaced the `$stripe->prices->search()` call with a direct `$stripe->prices->retrieve()` using `$product->default_price`
- Moved validation logic to check `active` status and `recurring` type after retrieval instead of before
- Eliminated the intermediate search result check, reducing API calls and simplifying the code flow

## Implementation Details
- The change leverages Stripe's built-in `default_price` field on products, which already points to the appropriate price
- Validation now occurs on the retrieved price object itself rather than on search results
- This approach is more efficient as it reduces the number of Stripe API calls from two to one per product

https://claude.ai/code/session_014sRqmozfa6hRNzur5ZC8kp