### PR TITLE
Refactor Docker build workflow for multi-platform support

### DIFF
--- a/.github/workflows/dockerBuild.yml
+++ b/.github/workflows/dockerBuild.yml
@@ -102,7 +102,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          context: git
+          context: workflow
           labels: |
             maintainer=adam-rms
             org.opencontainers.image.source=https://github.com/adam-rms/adam-rms
@@ -122,14 +122,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest list and push
+        id: create_manifest
         working-directory: /tmp/digests
         run: |
           TAG_ARGS=()
           while IFS= read -r tag; do
             TAG_ARGS+=( -t "$tag" )
           done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          docker buildx imagetools create "${TAG_ARGS[@]}" \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          DIGEST=$(docker buildx imagetools create -q "${TAG_ARGS[@]}" \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *))
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.docker_github_meta.outputs.version }}
@@ -137,5 +139,5 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY_IMAGE }}
-          subject-digest: ${{ steps.docker_github_meta.outputs.digest }}
+          subject-digest: ${{ steps.create_manifest.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
## Summary
Since https://github.com/adam-rms/adam-rms/pull/639 builds have been very slow (20 minutes+) 

Refactored the Docker Build & Push workflow to use a matrix strategy for building multi-platform images separately, then merging them into a single manifest list. This improves build efficiency and clarity by separating platform-specific builds from manifest creation.

## Key Changes
- **Matrix-based builds**: Split the build job into separate runs for `linux/amd64` and `linux/arm64` platforms using different runners
- **Artifact-based manifest merging**: Changed from building all platforms in a single step to building each platform separately and uploading digests as artifacts
- **New merge job**: Added a dedicated `merge` job that downloads digests and creates the final multi-platform manifest list
- **Removed QEMU**: Eliminated the need for QEMU setup by using native ARM runners (`ubuntu-24.04-arm`)
- **Environment variable**: Introduced `REGISTRY_IMAGE` env var for DRY principle
- **Improved caching**: Scoped build cache by platform to prevent cross-platform cache conflicts
- **Simplified permissions**: Moved `id-token` and `attestations` write permissions to the merge job where they're actually needed

## Implementation Details
- Each platform build outputs images by digest without pushing tags
- Digests are exported to artifacts with platform-specific naming
- The merge job reconstructs the full manifest using `docker buildx imagetools create`
- Attestation is now performed on the final merged image rather than individual platform builds
- Build cache is now scoped per platform to avoid potential issues with mixed-architecture caches

https://claude.ai/code/session_019kirMeV9xuLB7To7coxipp