### PR TITLE
Don't delete references to files when an instance is deleted, to avoid orphaned files in S3

### DIFF
--- a/db/migrations/20260419113000_s3files_do_not_delete_on_instance_deletion.php
+++ b/db/migrations/20260419113000_s3files_do_not_delete_on_instance_deletion.php
@@ -35,7 +35,11 @@ final class S3FilesDoNotDeleteOnInstanceDeletion extends AbstractMigration
                 'instances_id',
                 'instances',
                 'instances_id',
-                ['delete' => 'SET_NULL', 'update' => 'CASCADE']
+                [
+                    'constraint' => 's3files_instances_instances_id_fk',
+                    'delete' => 'SET_NULL',
+                    'update' => 'CASCADE',
+                ]
             )
             ->update();
     }

--- a/db/migrations/20260419113000_s3files_do_not_delete_on_instance_deletion.php
+++ b/db/migrations/20260419113000_s3files_do_not_delete_on_instance_deletion.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Db\Adapter\MysqlAdapter;
+use Phinx\Migration\AbstractMigration;
+
+final class S3FilesDoNotDeleteOnInstanceDeletion extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $this
+            ->table('s3files')
+            ->changeColumn(
+                'instances_id',
+                'integer',
+                [
+                    'null' => true,
+                    'comment' => 'The ID of the instance this file is associated with. Nullable because files may be retained even after instance deletion.',
+                ]
+            )
+            ->dropForeignKey('instances_id')
+            ->addForeignKey(
+                'instances_id',
+                'instances',
+                'instances_id',
+                ['delete' => 'SET_NULL', 'update' => 'CASCADE']
+            )
+            ->update();
+    }
+}

--- a/db/migrations/20260419113000_s3files_do_not_delete_on_instance_deletion.php
+++ b/db/migrations/20260419113000_s3files_do_not_delete_on_instance_deletion.php
@@ -22,6 +22,7 @@ final class S3FilesDoNotDeleteOnInstanceDeletion extends AbstractMigration
     {
         $this
             ->table('s3files')
+            ->dropForeignKey('instances_id')
             ->changeColumn(
                 'instances_id',
                 'integer',
@@ -30,7 +31,6 @@ final class S3FilesDoNotDeleteOnInstanceDeletion extends AbstractMigration
                     'comment' => 'The ID of the instance this file is associated with. Nullable because files may be retained even after instance deletion.',
                 ]
             )
-            ->dropForeignKey('instances_id')
             ->addForeignKey(
                 'instances_id',
                 'instances',

--- a/src/api/instances/permanentlyDelete.php
+++ b/src/api/instances/permanentlyDelete.php
@@ -7,6 +7,11 @@ $DBLIB->where('instances_id', $_POST['instances_id']);
 $DBLIB->where("instances_deleted", 1);
 if (!$DBLIB->getOne("instances", "instances_id")) finish(false);
 
+// Delete all files associated with this instance that haven't already been marked for deletion. This ensures that when the instance is permanently deleted, there are no remaining files that are still accessible.
+$DBLIB->where('instances_id', $_POST['instances_id']);
+$DBLIB->where('s3files_meta_deleteOn', null);
+$update = $DBLIB->update("s3files", ["s3files_meta_deleteOn" => date('Y-m-d H:i:s')], 1);
+
 $DBLIB->where('instances_id', $_POST['instances_id']);
 $DBLIB->where("instances_deleted", 1);
 if($DBLIB->delete('instances')) {

--- a/src/api/instances/permanentlyDelete.php
+++ b/src/api/instances/permanentlyDelete.php
@@ -10,7 +10,7 @@ if (!$DBLIB->getOne("instances", "instances_id")) finish(false);
 // Delete all files associated with this instance that haven't already been marked for deletion. This ensures that when the instance is permanently deleted, there are no remaining files that are still accessible.
 $DBLIB->where('instances_id', $_POST['instances_id']);
 $DBLIB->where('s3files_meta_deleteOn', null);
-$update = $DBLIB->update("s3files", ["s3files_meta_deleteOn" => date('Y-m-d H:i:s')], 1);
+$update = $DBLIB->update("s3files", ["s3files_meta_deleteOn" => date('Y-m-d H:i:s', strtotime('-5 minutes'))]);
 
 $DBLIB->where('instances_id', $_POST['instances_id']);
 $DBLIB->where("instances_deleted", 1);


### PR DESCRIPTION
This pull request updates how S3 file records are handled when an instance is permanently deleted. The migration changes the foreign key constraint so that files are not automatically deleted when their associated instance is removed, and the API logic is updated to explicitly mark related files for deletion before the instance is deleted.

**Database schema changes:**

* Updated the `s3files` table so that the `instances_id` foreign key is now nullable, and changed the foreign key constraint to `SET_NULL` on instance deletion, preventing automatic deletion of files when their associated instance is deleted.

**Instance deletion logic:**

* Modified the instance deletion API (`permanentlyDelete.php`) to explicitly mark all files associated with the instance for deletion by setting their `s3files_meta_deleteOn` field before deleting the instance, ensuring no files remain accessible after instance removal.