### PR TITLE
Instant keyword asset search, with the advanced filters combining into it

### DIFF
--- a/src/assets.php
+++ b/src/assets.php
@@ -19,6 +19,8 @@ $SEARCH = [
     "PROJECT_REFERER" => $_GET['project_referer'] ?: false,
     "PAGE" =>  $_GET['page'] ? intval($_GET['page']) : 1,
     "PAGE_LIMIT" => $_GET['resultsperpage'] ? intval($_GET['resultsperpage']) : 20,
+    "SIMPLE" => (isset($_GET['simple']) and $_GET['simple'] == '1'),
+    "SIMPLE_KEYWORD" => isset($_GET['simple_keyword']) ? trim((string)$_GET['simple_keyword']) : '',
     "SETTINGS" => [
         "SHOWLINKED" => ($_GET['showlinked'] == 1 ? true : false),
         "SHOWARCHIVED" => ($_GET['showarchived'] == 1 ? true : false),
@@ -112,7 +114,59 @@ if (count($sortArray) == 2) {
 $DBLIB->orderBy("assetTypes.assetTypes_name", "ASC"); // Last item in the sort each time
 
 //Keywords
-if (count($SEARCH['TERMS']['KEYWORDS']) > 0) {
+if ($SEARCH['SIMPLE']) {
+    // Broad AssetType keyword match: name, description, manufacturer, category name,
+    // category-group name, and physical-asset tag. Each whitespace-separated term must
+    // match somewhere.
+    if ($SEARCH['SIMPLE_KEYWORD'] !== '') {
+        // Keep every non-empty term (including the literal "0", which a callback-less
+        // array_filter() would wrongly drop), then bound the query by capping the number
+        // of terms and the length of each so a pathological input can't build a huge WHERE.
+        $terms = array_values(array_filter(
+            preg_split('/\s+/', $SEARCH['SIMPLE_KEYWORD']),
+            function ($t) { return strlen(trim((string)$t)) > 0; }
+        ));
+        $terms = array_slice($terms, 0, 10);
+        $terms = array_map(function ($t) { return substr($t, 0, 100); }, $terms);
+        if (count($terms) > 0) {
+            $instanceIdInt = intval($SEARCH['INSTANCE_ID']);
+            $keywordNow = date("Y-m-d H:i:s");
+            $andClauses = [];
+            $allValues = [];
+            foreach ($terms as $term) {
+                $like = '%' . $term . '%';
+                // Mirror the linked/archived constraints the main results query applies so a
+                // tag match can't surface a type whose matching asset is filtered out below.
+                $existsExtra = '';
+                $existsExtraValues = [];
+                if (!$SEARCH['SETTINGS']['SHOWARCHIVED']) {
+                    $existsExtra .= "\n                          AND (a2.assets_endDate IS NULL OR a2.assets_endDate >= ?)";
+                    $existsExtraValues[] = $keywordNow;
+                }
+                if (!$SEARCH['SETTINGS']['SHOWLINKED']) {
+                    $existsExtra .= "\n                          AND a2.assets_linkedTo IS NULL";
+                }
+                $andClauses[] = "(
+                    assetTypes.assetTypes_name LIKE ?
+                    OR assetTypes.assetTypes_description LIKE ?
+                    OR manufacturers.manufacturers_name LIKE ?
+                    OR assetCategories.assetCategories_name LIKE ?
+                    OR assetCategoriesGroups.assetCategoriesGroups_name LIKE ?
+                    OR EXISTS (
+                        SELECT 1 FROM assets a2
+                        WHERE a2.assetTypes_id = assetTypes.assetTypes_id
+                          AND a2.instances_id = ?
+                          AND a2.assets_deleted = 0
+                          AND a2.assets_tag LIKE ?" . $existsExtra . "
+                    )
+                )";
+                array_push($allValues, $like, $like, $like, $like, $like, $instanceIdInt, $like);
+                foreach ($existsExtraValues as $ev) $allValues[] = $ev;
+            }
+            $DBLIB->where('(' . implode(' AND ', $andClauses) . ')', $allValues);
+        }
+    }
+} elseif (count($SEARCH['TERMS']['KEYWORDS']) > 0) {
     $thisWhere = false;
     $thisValues = [];
     foreach ($SEARCH['TERMS']['KEYWORDS'] as $word) {

--- a/src/assets.twig
+++ b/src/assets.twig
@@ -17,6 +17,7 @@
             {% endfor %}
         {% endif %}
         <form method="get" action="{{CONFIG.ROOTURL}}/assets.php" id="assetSearchForm">
+            <input type="hidden" name="simple" id="assetSearchSimpleFlag" value="1">
             <div class="card">
                 <div class="card-header">
                     <h3 class="card-title">Assets</h3>
@@ -30,126 +31,146 @@
                 </div>
                 <div class="card-body">
                     <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
-                            <div class="form-group">
-                                <label>Keyword</label>
-                                <select class="form-control select2bs4" multiple="multiple" name="keyword[]">
-                                    {% for term in searchResults.SEARCH.TERMS.KEYWORDS %}
-                                        <option value="{{ term }}" selected>{{ term }}</option>
-                                    {% endfor %}
-                                </select>
-                                <small class="form-text text-muted">Seperate multiple keywords with a comma</small>
+                        <div class="col-12 col-lg-7">
+                            <div id="assetSearchSimpleField" class="form-group mb-2">
+                                <label for="assetSearchSimpleKeyword" class="mb-1">Keyword</label>
+                                <input type="text" id="assetSearchSimpleKeyword" name="simple_keyword" class="form-control" value="{{ searchResults.SEARCH.SIMPLE_KEYWORD }}" placeholder="Search assets by name, tag, category, manufacturer, group…" autocomplete="off">
+                                <small class="form-text text-muted">Searches asset name, description, tag, category, manufacturer and group.</small>
                             </div>
-                            <div class="form-group">
-                                <label>Tag</label>
-                                <select class="form-control select2bs4" multiple="multiple" name="tags[]">
-                                    {% for tag in searchResults.SEARCH.TERMS.TAGS %}
-                                        <option value="{{ tag }}" selected>{{ tag }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Manufacturer</label>
-                                <select class="form-control select2bs4" multiple name="manufacturer[]">
-                                    {% for manufacturer in searchResults.SEARCH['SELECTED_TERMS']['MANUFACTURER'] %}
-                                        <option value="{{ manufacturer.manufacturers_id }}" selected>{{ manufacturer.manufacturers_name }}</option>
-                                    {% endfor %}
-                                </select>
+                        </div>
+                        <div class="col-12 col-lg-5" id="assetSearchScopeBar">
+                            <div class="form-group mb-2">
+                                <label class="mb-0"><small class="text-muted">Business</small></label>
+                                <select class="form-control select2 select2bs4" name="instance_id">
+                                        {% for instance in USERDATA.instances %}
+                                            <option {{ searchResults.SEARCH.INSTANCE_ID == instance.instances_id ? 'selected' : '' }}  value="{{instance.instances_id}}">{{instance.instances_name}}</option>
+                                        {% endfor %}
+                                    </select>
                             </div>
                             
+                            
+                            <div class="form-row" id="assetSearchScopeInline">
+                                <div class="form-group col-auto mb-2" style="min-width:14rem;">
+                                    <label class="mb-0"><small class="text-muted">Sort by</small></label>
+                                    <select class="form-control select2 select2bs4" name="sort">
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "price-a" ? 'selected' : '' }}  value="price-a">Weekly Price (low-high)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "price-d" ? 'selected' : '' }}  value="price-d">Weekly Price (high-low)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "value-a" ? 'selected' : '' }}  value="value-a">Value (low-high)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "value-d" ? 'selected' : '' }}  value="value-d">Value (high-low)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "alphabet-a" ? 'selected' : '' }}  value="alphabet-a">Alphabetical (A-Z)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "alphabet-d" ? 'selected' : '' }}  value="alphabet-d">Alphabetical (Z-A)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "mass-a" ? 'selected' : '' }}  value="mass-a">Mass (low-high)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "mass-d" ? 'selected' : '' }}  value="mass-d">Mass (high-low)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "date-d" ? 'selected' : '' }}  value="date-d">Date Added (most recent first)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "date-a" ? 'selected' : '' }}  value="date-a">Date Added (oldest first)</option>
+                                    </select>
+                                </div>
+                                <div class="form-group col-auto mb-2" style="min-width:8rem;">
+                                    <label class="mb-0"><small class="text-muted">Per page</small></label>
+                                    <select class="form-control select2 select2bs4" name="resultsperpage">
+                                        <option {{ searchResults.SEARCH.PAGE_LIMIT == 10 ? 'selected' : '' }}>10</option>
+                                        <option {{ searchResults.SEARCH.PAGE_LIMIT == 20 ? 'selected' : '' }}>20</option>
+                                        <option {{ searchResults.SEARCH.PAGE_LIMIT == 50 ? 'selected' : '' }}>50</option>
+                                        <option {{ searchResults.SEARCH.PAGE_LIMIT == 100 ? 'selected' : '' }}>100</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="mb-1">
+                                <label class="d-block mb-1" style="font-weight:normal;"><input type="checkbox" name="hideimages" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.HIDEIMAGES ? "checked" : "" }}> Hide asset images</label>
+                            </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
-                            <div class="form-group">
-                                <label>Group</label>
-                                <select class="form-control select2bs4" name="group[]" multiple>
-                                    {% for group in searchResults.SEARCH['SELECTED_TERMS']['GROUPS'] %}
-                                        <option value="{{ group.assetGroups_id }}" selected>{{ group.assetGroups_name }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Category</label>
-                                <select class="form-control select2bs4" multiple name="category[]">
-                                    {% for category in searchResults.SEARCH['SELECTED_TERMS']['CATEGORY'] %}
-                                        <option value="{{ category.assetCategories_id }}" selected>{{ category.assetCategoriesGroups_name }} - {{ category.assetCategories_name }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Business</label>
-                                <select class="form-control select2 select2bs4" name="instance_id">
-                                    {% for instance in USERDATA.instances %}
-                                        <option {{ searchResults.SEARCH.INSTANCE_ID == instance.instances_id ? 'selected' : '' }}  value="{{instance.instances_id}}">{{instance.instances_name}}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        </div>
-                        <div class="col-12 col-md-6 col-lg-4">
-                            {% if "PROJECTS:PROJECT_ASSETS:CREATE:ASSIGN_AND_UNASSIGN"|instancePermissions %}
+                    </div>
+                    <div class="mb-2">
+                        <a href="#" id="assetSearchAdvancedToggle" role="button" aria-expanded="false" aria-controls="assetSearchAdvanced">
+                            <i class="fas fa-caret-right" id="assetSearchAdvancedToggleIcon"></i>
+                            <span id="assetSearchAdvancedToggleLabel">Advanced filters</span>
+                        </a>
+                    </div>
+                    <div id="assetSearchAdvanced" style="display:none;">
+                        <hr>
+                        <div class="row">
+                            <div class="col-12 col-md-6 col-lg-4">
                                 <div class="form-group">
-                                    <label>Project to assign assets to</label>
-                                    <select class="form-control select2 select2bs4" name="project">
-                                        <option value="">No project selected</option>
-                                        {% for project in searchOptions.projects %}
-                                            <option {{ searchResults.SEARCH.PROJECT_ID == project.projects_id ? 'selected' : '' }}  value="{{ project.projects_id }}">{{ project.projects_name }}{{ project.clients_name ? " | " ~ project.clients_name : "" }}</option>
+                                    <label>Tag</label>
+                                    <select class="form-control select2bs4" multiple="multiple" name="tags[]">
+                                        {% for tag in searchResults.SEARCH.TERMS.TAGS %}
+                                            <option value="{{ tag }}" selected>{{ tag }}</option>
                                         {% endfor %}
                                     </select>
                                 </div>
-                                {% if searchResults.SEARCH.PROJECT_ID == searchResults.SEARCH.PROJECT_REFERER %}
-                                    <input type="hidden" name="project_referer" value="{{ searchResults.SEARCH.PROJECT_REFERER }}">
+                                <div class="form-group">
+                                    <label>Manufacturer</label>
+                                    <select class="form-control select2bs4" multiple name="manufacturer[]">
+                                        {% for manufacturer in searchResults.SEARCH['SELECTED_TERMS']['MANUFACTURER'] %}
+                                            <option value="{{ manufacturer.manufacturers_id }}" selected>{{ manufacturer.manufacturers_name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+
+                            </div>
+                            <div class="col-12 col-md-6 col-lg-4">
+                                <div class="form-group">
+                                    <label>Group</label>
+                                    <select class="form-control select2bs4" name="group[]" multiple>
+                                        {% for group in searchResults.SEARCH['SELECTED_TERMS']['GROUPS'] %}
+                                            <option value="{{ group.assetGroups_id }}" selected>{{ group.assetGroups_name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label>Category</label>
+                                    <select class="form-control select2bs4" multiple name="category[]">
+                                        {% for category in searchResults.SEARCH['SELECTED_TERMS']['CATEGORY'] %}
+                                            <option value="{{ category.assetCategories_id }}" selected>{{ category.assetCategoriesGroups_name }} - {{ category.assetCategories_name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                                
+                            </div>
+                            <div class="col-12 col-md-6 col-lg-4">
+                                {% if "PROJECTS:PROJECT_ASSETS:CREATE:ASSIGN_AND_UNASSIGN"|instancePermissions %}
+                                    <div class="form-group">
+                                        <label>Project to assign assets to</label>
+                                        <select class="form-control select2 select2bs4" name="project">
+                                            <option value="">No project selected</option>
+                                            {% for project in searchOptions.projects %}
+                                                <option {{ searchResults.SEARCH.PROJECT_ID == project.projects_id ? 'selected' : '' }}  value="{{ project.projects_id }}">{{ project.projects_name }}{{ project.clients_name ? " | " ~ project.clients_name : "" }}</option>
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                    {% if searchResults.SEARCH.PROJECT_ID == searchResults.SEARCH.PROJECT_REFERER %}
+                                        <input type="hidden" name="project_referer" value="{{ searchResults.SEARCH.PROJECT_REFERER }}">
+                                    {% endif %}
+                                {% else %}
+                                <div class="form-group">
+                                    <label>Show availability between</label>
+                                    <input type="text" class="form-control" name="dates" value="{{ searchResults.SEARCH.TERMS['DATE-START'] ? searchResults.SEARCH.TERMS['DATE-START'] ~ " - " ~ searchResults.SEARCH.TERMS['DATE-END'] }}" />
+                                </div>
                                 {% endif %}
-                            {% else %}
-                            <div class="form-group">
-                                <label>Show availability between</label>
-                                <input type="text" class="form-control" name="dates" value="{{ searchResults.SEARCH.TERMS['DATE-START'] ? searchResults.SEARCH.TERMS['DATE-START'] ~ " - " ~ searchResults.SEARCH.TERMS['DATE-END'] }}" />
-                            </div>
-                            {% endif %}
-                            <div class="form-group">
-                                <label>Number of results per page</label>
-                                <select class="form-control select2 select2bs4" name="resultsperpage">
-                                    <option {{ searchResults.SEARCH.PAGE_LIMIT == 10 ? 'selected' : '' }}>10</option>
-                                    <option {{ searchResults.SEARCH.PAGE_LIMIT == 20 ? 'selected' : '' }}>20</option>
-                                    <option {{ searchResults.SEARCH.PAGE_LIMIT == 50 ? 'selected' : '' }}>50</option>
-                                    <option {{ searchResults.SEARCH.PAGE_LIMIT == 100 ? 'selected' : '' }}>100</option>
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Sort by</label>
-                                <select class="form-control select2 select2bs4" name="sort">
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "price-a" ? 'selected' : '' }}  value="price-a">Weekly Price (low-high)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "price-d" ? 'selected' : '' }}  value="price-d">Weekly Price (high-low)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "value-a" ? 'selected' : '' }}  value="value-a">Value (low-high)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "value-d" ? 'selected' : '' }}  value="value-d">Value (high-low)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "alphabet-a" ? 'selected' : '' }}  value="alphabet-a">Alphabetical (A-Z)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "alphabet-d" ? 'selected' : '' }}  value="alphabet-d">Alphabetical (Z-A)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "mass-a" ? 'selected' : '' }}  value="mass-a">Mass (low-high)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "mass-d" ? 'selected' : '' }}  value="mass-d">Mass (high-low)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "date-d" ? 'selected' : '' }}  value="date-d">Date Added (most recent first)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "date-a" ? 'selected' : '' }}  value="date-a">Date Added (oldest first)</option>
-                                </select>
-                            </div>
-                            <div class="mb-1">
-                                <input type="checkbox" name="showlinked" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.SHOWLINKED ? "checked" : "" }}>
-                                <span>Show assets linked to others</span>
-                            </div>
-                            <div class="mb-1">
-                                <input type="checkbox" name="showarchived" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.SHOWARCHIVED ? "checked" : "" }}>
-                                <span>Show archived assets</span>
-                            </div>
-                            <div class="mb-1">
-                                <input type="checkbox" name="hideimages" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.HIDEIMAGES ? "checked" : "" }}>
-                                <span>Hide asset images</span>
+                                <div class="form-group">
+                                    <label class="d-block mb-1" style="font-weight:normal;"><input type="checkbox" name="showlinked" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.SHOWLINKED ? "checked" : "" }}> Show assets linked to others</label>
+                                    <label class="d-block mb-1" style="font-weight:normal;"><input type="checkbox" name="showarchived" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.SHOWARCHIVED ? "checked" : "" }}> Show archived assets</label>
+                                </div>
+                                
+                                
+                                
+                                
+                                
                             </div>
                         </div>
                     </div>
                 </div>
-                <div class="card-footer">
+                <div class="card-footer" id="assetSearchAdvancedFooter" style="display:none;">
                     <button type="submit" class="btn btn-primary btn-lg ">Search</button>
                 </div>
             </div>
         </form>
     </div>
-    <div class="col-12">
+    <div class="col-12" style="position:relative;">
+        <div id="assetSearchLoading" style="display:none;position:absolute;inset:0;z-index:10;background:rgba(255,255,255,0.55);text-align:center;padding-top:60px;">
+            <i class="fas fa-spinner fa-spin fa-2x text-primary"></i>
+        </div>
+        <div id="assetSearchResults">
         {% if searchResults.ASSETS %}
         <div class="card card-solid">
             <div class="card-header">
@@ -438,6 +459,7 @@
             </div>
         </div>
         {% endif %}
+        </div>
     </div>
 </div>
 <script>
@@ -448,7 +470,217 @@ function replaceQueryParam(param, newval, search) {
     return (query.length > 2 ? query + "&" : "?") + (newval ? param + "=" + newval : '');
 }
 $(document).ready(function () {
-    $('#assetSearchForm input[name ="dates"]').daterangepicker({
+    var $form = $('#assetSearchForm');
+    var $simpleField = $('#assetSearchSimpleField');
+    var $simpleKeyword = $('#assetSearchSimpleKeyword');
+    var $simpleFlag = $('#assetSearchSimpleFlag');
+    var $advancedSection = $('#assetSearchAdvanced');
+    var $advancedFooter = $('#assetSearchAdvancedFooter');
+    var $advancedToggle = $('#assetSearchAdvancedToggle');
+    var $advancedToggleIcon = $('#assetSearchAdvancedToggleIcon');
+    var $advancedToggleLabel = $('#assetSearchAdvancedToggleLabel');
+    var $results = $('#assetSearchResults');
+    var $loading = $('#assetSearchLoading');
+
+    // Fields that represent action-context (not result-filters) and must survive
+    // the collapse/simple-mode wipe. `project` is the target for "add to project"
+    // buttons on each result card; `project_referer` is its paired hidden marker.
+    var ADVANCED_EXEMPT_FROM_RESET = { 'project': 1, 'project_referer': 1 };
+
+    // Reset every Advanced-section field (the content filters: keyword, tags,
+    // manufacturer, group, category, dates) to its HTML-default value. Called on
+    // collapse and on initial load so a hidden filter can never silently influence a
+    // simple search. Scope controls (business, sort, per-page, the checkboxes) live in
+    // the always-visible bar outside this section and are deliberately NOT reset here.
+    // Uses defaultSelected/defaultChecked/defaultValue instead of the browser's
+    // first-option pick.
+    function resetAdvancedFields() {
+        $advancedSection.find('input, select, textarea').each(function () {
+            var el = this;
+            if (el.name && ADVANCED_EXEMPT_FROM_RESET[el.name]) return;
+            if (el.type === 'checkbox' || el.type === 'radio') {
+                el.checked = el.defaultChecked;
+            } else if (el.tagName === 'SELECT') {
+                var anyDefault = false;
+                $(el).find('option').each(function () {
+                    this.selected = this.defaultSelected;
+                    if (this.defaultSelected) anyDefault = true;
+                });
+                // If no option had `selected` in the HTML, force nothing selected
+                // (rather than letting the browser keep its first-option pick alive).
+                if (!anyDefault && !el.multiple) {
+                    el.selectedIndex = -1;
+                }
+                // .select2 namespace refreshes select2's UI without firing our
+                // top-level `change` handler (which would re-trigger a search).
+                $(el).trigger('change.select2');
+            } else {
+                el.value = el.defaultValue;
+            }
+        });
+    }
+
+    // Advanced always starts collapsed — deliberately do not persist state.
+    var advancedOpen = false;
+    function applyAdvancedVisibility() {
+        if (advancedOpen) {
+            $advancedSection.show();
+            $advancedFooter.show();
+            $advancedToggleIcon.removeClass('fa-caret-right').addClass('fa-caret-down');
+            $advancedToggleLabel.text('Hide advanced filters');
+            $advancedToggle.attr('aria-expanded', 'true');
+        } else {
+            $advancedSection.hide();
+            $advancedFooter.hide();
+            $advancedToggleIcon.removeClass('fa-caret-down').addClass('fa-caret-right');
+            $advancedToggleLabel.text('Advanced filters');
+            $advancedToggle.attr('aria-expanded', 'false');
+            // Clear the advanced content filters when hiding them, so a filter left
+            // set in a collapsed panel can never silently narrow the search. The
+            // keyword box and scope bar sit outside the panel and stay put.
+            resetAdvancedFields();
+        }
+    }
+    applyAdvancedVisibility();
+    $advancedToggle.on('click', function (e) {
+        e.preventDefault();
+        advancedOpen = !advancedOpen;
+        applyAdvancedVisibility();
+        // Do not trigger a search — visibility toggle only.
+    });
+
+    // --- Auto-search machinery ---------------------------------------------
+    var debounceTimer = null;
+    var currentAbort = null;
+
+    // Strict allow-lists per mode. Anything not in the active mode's list is dropped
+    // from the URL, so a hidden/stale DOM value in the other mode can never
+    // silently influence the search backend receives.
+    //
+    // `project` / `project_referer` appear in BOTH lists — they're action-context
+    // (target for "add to project" on each result card), not a result filter, and
+    // must reach the backend regardless of collapse state so the buttons work.
+    // One query shape: the keyword box + scope bar always search, and the Advanced
+    // filters (tag/manufacturer/group/category/dates) combine on top. keyword[] is
+    // intentionally absent - the single keyword box above replaces it.
+    var QUERY_ALLOW = {
+        'simple': 1, 'simple_keyword': 1, 'page': 1,
+        'project': 1, 'project_referer': 1,
+        'instance_id': 1, 'resultsperpage': 1, 'sort': 1,
+        'showlinked': 1, 'showarchived': 1, 'hideimages': 1,
+        'tags[]': 1, 'manufacturer[]': 1, 'group[]': 1, 'category[]': 1, 'dates': 1,
+    };
+
+    function buildQueryString(overridePage) {
+        var params = new URLSearchParams();
+        var allow = QUERY_ALLOW;
+        $form.find('input, select, textarea').each(function () {
+            var el = this;
+            var name = el.name;
+            if (!name || !allow[name]) return;
+            if (el.type === 'checkbox' || el.type === 'radio') {
+                if (el.checked) params.append(name, el.value);
+                return;
+            }
+            if (el.tagName === 'SELECT' && el.multiple) {
+                $(el).find('option:selected').each(function () {
+                    params.append(name, this.value);
+                });
+                return;
+            }
+            var val = el.value;
+            if (val === '' || val == null) return;
+            params.append(name, val);
+        });
+        if (overridePage != null) {
+            params.delete('page');
+            params.append('page', overridePage);
+        }
+        return params.toString();
+    }
+
+    function runSearch(overridePage) {
+        if (currentAbort) {
+            currentAbort.abort();
+        }
+        var qs = buildQueryString(overridePage);
+        var url = "{{ CONFIG.ROOTURL }}/assets.php?" + qs;
+        currentAbort = new AbortController();
+        $loading.stop(true, true).fadeIn(80);
+        fetch(url, {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            credentials: 'same-origin',
+            signal: currentAbort.signal
+        }).then(function (r) {
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            return r.text();
+        }).then(function (html) {
+            var doc = new DOMParser().parseFromString(html, 'text/html');
+            var next = doc.getElementById('assetSearchResults');
+            if (!next) throw new Error('No results block in response');
+            // Preserve the overlay element by swapping only inner content.
+            $results.html(next.innerHTML);
+            // Rebind carousels inside the new results.
+            $results.find('.slick').slick({
+                dots: false,
+                arrows: false,
+                focusOnSelect: true,
+                pauseOnHover: true,
+                draggable: false,
+                infinite: true,
+                slidesToShow: 1,
+                slidesToScroll: 1,
+                autoplay: true,
+                autoplaySpeed: 2000,
+            });
+            // Update URL (without page reload) so bookmarks / refresh work.
+            history.replaceState(null, '', window.location.pathname + '?' + qs);
+        }).catch(function (err) {
+            if (err.name === 'AbortError') return;
+            console.error('Asset search failed', err);
+        }).finally(function () {
+            $loading.stop(true, true).fadeOut(120);
+        });
+    }
+
+    function scheduleSearch(delayMs) {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(function () {
+            debounceTimer = null;
+            runSearch(1); // any filter change resets to page 1
+        }, delayMs);
+    }
+
+    // Debounced input on the simple keyword field.
+    $simpleKeyword.on('input', function () { scheduleSearch(500); });
+
+    // Immediate change on the always-visible scope bar (business, sort, per-page,
+    // the three checkboxes) - applies in both quick and advanced mode.
+    $('#assetSearchScopeBar').on('change', 'input, select', function () {
+        scheduleSearch(0);
+    });
+
+    // Immediate change on every advanced filter control.
+    $advancedSection.on('change', 'input, select, textarea', function () {
+        // Skip when the change is on the daterangepicker's internal state (we
+        // already listen for apply/cancel separately).
+        scheduleSearch(0);
+    });
+
+    // Manual search button — submit fires immediately, cancelling any pending.
+    $form.on('submit', function (e) {
+        e.preventDefault();
+        if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+        runSearch(1);
+    });
+
+    // Pagination — swap results instead of full navigation.
+    $(document).on('click', '#assetSearchResults .page-link[data-page]', function (e) {
+        e.preventDefault();
+        runSearch($(this).data('page'));
+    });
+
+    $form.find('input[name ="dates"]').daterangepicker({
         timePicker: true,
         timePickerIncrement: 15,
         locale: {
@@ -458,22 +690,15 @@ $(document).ready(function () {
     });
     $('#assetSearchForm input[name ="dates"]').on('apply.daterangepicker', function(ev, picker) {
         $(this).val(picker.startDate.format('DD MMM YYYY hh:mm A') + ' - ' + picker.endDate.format('DD MMM YYYY hh:mm A'));
+        scheduleSearch(0);
     });
     $('#assetSearchForm input[name ="dates"]').on('cancel.daterangepicker', function(ev, picker) {
         $(this).val('');
+        scheduleSearch(0);
     });
     $('#assetSearchForm .select2').select2({
         theme: "bootstrap4",
         width: '100%'
-    });
-    $('#assetSearchForm select[name ="keyword[]"]').select2({
-        tags: true,
-        tokenSeparators: [',', ';'],
-        multiple: true,
-        theme: "bootstrap4",
-        minimumInputLength: 1,
-        width: '100%',
-        placeholder: "SD7T, Viper, Wash, Condenser, CYC, Dynamic, Clamp",
     });
     $('#assetSearchForm select[name ="tags[]"]').select2({
         tags: true,
@@ -591,11 +816,6 @@ $(document).ready(function () {
             }
         }
     });
-    $(document).on("click",".page-link[data-page]",function () {
-        var str = window.location.search
-        str = replaceQueryParam('page', $(this).data("page"), str)
-        window.location = window.location.pathname + str
-    });
     const Toast = Swal.mixin({
         toast: true,
         position: 'top-end',
@@ -615,21 +835,39 @@ $(document).ready(function () {
         autoplaySpeed: 2000,
     });
     {% if searchResults.PROJECT.ID != null and "PROJECTS:PROJECT_ASSETS:CREATE:ASSIGN_AND_UNASSIGN"|instancePermissions %}
-    $(".addToBasketAssetButton").click(function () {
-        var assetId=$(this).data("assetid");
-        ajaxcall("projects/assets/assign.php", {"assets_id":$(this).data("assetid"),"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
+    // Read the CURRENTLY selected project at click time. Auto-search swaps only the
+    // results container, not this outer script, so a project id baked in at page load
+    // would go stale the moment the user changes the project selector and cause
+    // assignments to POST to the wrong project.
+    function currentProjectId() {
+        var $sel = $('#assetSearchForm select[name="project"]');
+        if ($sel.length) return $sel.val() || '';
+        return "{{ searchResults.SEARCH.PROJECT_ID }}";
+    }
+    function currentProjectName() {
+        var $sel = $('#assetSearchForm select[name="project"]');
+        if ($sel.length && $sel.val()) {
+            // Option labels are rendered as "Project name | Client"; keep the name half.
+            return ($sel.find('option:selected').text().split(' | ')[0] || '').trim();
+        }
+        return "{{ searchResults.PROJECT.NAME }}";
+    }
+    // Delegated so that DOM swaps from auto-search don't detach these handlers.
+    $(document).on('click', '#assetSearchResults .addToBasketAssetButton', function () {
+        var assetId = $(this).data("assetid");
+        ajaxcall("projects/assets/assign.php", {"assets_id":assetId,"projects_id":currentProjectId()}, function (data) {
             $(".addToBasketAssetButton[data-assetid=" + assetId + "]").hide();
             $(".removeFromBasketAssetButton[data-assetid=" + assetId + "]").show();
             Toast.fire({
                 type: 'success',
-                title: 'Added to {{ searchResults.PROJECT.NAME }}'
+                title: 'Added to ' + currentProjectName()
             });
         });
     });
-    $(".addToBasketAssetTypeButton").click(function () {
+    $(document).on('click', '#assetSearchResults .addToBasketAssetTypeButton', function () {
         const thisButton = $(this);
         var assetTypeId = thisButton.data("assettypeid");
-        ajaxcall("projects/assets/assign.php", {"assetTypes_id":assetTypeId,"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
+        ajaxcall("projects/assets/assign.php", {"assetTypes_id":assetTypeId,"projects_id":currentProjectId()}, function (data) {
             var failedIds = (data.response && data.response.failed ? data.response.failed : []).map(function(f) { return f.assets_id; });
             $(".addToBasketAssetButton[data-assettypeid=" + assetTypeId + "]").each(function() {
                 var assetId = $(this).data("assetid");
@@ -641,11 +879,11 @@ $(document).ready(function () {
             thisButton.prop('disabled', true);
             Toast.fire({
                 type: 'success',
-                title: 'Added to {{ searchResults.PROJECT.NAME }}'
+                title: 'Added to ' + currentProjectName()
             });
         });
     });
-    $(".removeFromBasketAssetButton").click(function () {
+    $(document).on('click', '#assetSearchResults .removeFromBasketAssetButton', function () {
         var assetId = $(this).data("assetid");
         bootbox.confirm({
             message: "Are you sure you wish to remove this asset from the project?",
@@ -661,12 +899,12 @@ $(document).ready(function () {
             },
             callback: function (result) {
                 if (result) {
-                    ajaxcall("projects/assets/unassign.php", {"assets_id":assetId,"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
+                    ajaxcall("projects/assets/unassign.php", {"assets_id":assetId,"projects_id":currentProjectId()}, function (data) {
                         $(".addToBasketAssetButton[data-assetid=" + assetId + "]").show();
                         $(".removeFromBasketAssetButton[data-assetid=" + assetId + "]").hide();
                         Toast.fire({
                             type: 'success',
-                            title: 'Removed from {{ searchResults.PROJECT.NAME }}'
+                            title: 'Removed from ' + currentProjectName()
                         });
                     });
                 }


### PR DESCRIPTION
Closes #1011

## Problem
The Asset Search page leads with a large filter grid that has to be filled in and submitted before any results appear. Finding a single known item is slower than it should be for the common "I know roughly what it's called" case.

## What this changes
The page now leads with a single **Keyword** box that searches asset type name and description, manufacturer, category, category group, and the physical asset tag. Results, pagination and the URL update **as you type**, with no full page reload. Whitespace-separated terms each have to match, so words narrow the result set.

The detailed filters move behind an **Advanced filters** toggle and **combine with** the keyword rather than being a separate mode:

- A compact set of always-applied controls sits beside the keyword box — Business, Sort, results-per-page, and a Hide asset images toggle. They apply to every search (plain keyword searches included) and are never lost when the advanced panel is collapsed.
- The advanced panel (tag, manufacturer, group, category, Show linked / Show archived, dates or the project picker) expands **in place below** the keyword box rather than replacing it, so the layout does not jump.
- One keyword box drives every search; the advanced filters just add to it.
- Collapsing the advanced panel resets those content filters, so a filter left set in a hidden panel can never silently narrow a search. The keyword box and the scope controls beside it are kept.

## Implementation notes
- Server side this is a new branch in the keyword `WHERE` builder, selected by the `simple` / `simple_keyword` request parameters; the other filters were already additive, so they layer on unchanged.
- The existing advanced-keyword path is left in place — this adds a route, it does not rewrite the old one.
- Instance scoping is preserved: no query runs unscoped from the current instance.
- Touches only `src/assets.php` and `src/assets.twig`; no build step (jQuery/Bootstrap via CDN) and no schema change.

## How to test
1. On the asset list, type in the Keyword box — results, the pager and the URL update without a reload; a second word narrows the set.
2. Keyword matches asset type name/description, manufacturer, category, category group, and a physical asset tag.
3. Open Advanced filters — the panel expands below without the page jumping; setting e.g. a manufacturer narrows the current keyword results.
4. Collapse Advanced filters — the content filters reset, but the keyword and the Business / Sort / per-page / Hide-images controls stay.
5. Reload a URL produced while searching — it reproduces the same results.

## Related
- #304 (closed) — the earlier "Asset Search & Filtering v3" discussion about rethinking the selector, including sharable URL searches. This delivers a focused slice of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
