### PR TITLE
[FEATURE] Show Asset Groups as result cards in the asset search

### DIFF
--- a/src/assets.php
+++ b/src/assets.php
@@ -19,6 +19,8 @@ $SEARCH = [
     "PROJECT_REFERER" => $_GET['project_referer'] ?: false,
     "PAGE" =>  $_GET['page'] ? intval($_GET['page']) : 1,
     "PAGE_LIMIT" => $_GET['resultsperpage'] ? intval($_GET['resultsperpage']) : 20,
+    "SIMPLE" => (isset($_GET['simple']) and $_GET['simple'] == '1'),
+    "SIMPLE_KEYWORD" => isset($_GET['simple_keyword']) ? trim((string)$_GET['simple_keyword']) : '',
     "SETTINGS" => [
         "SHOWLINKED" => ($_GET['showlinked'] == 1 ? true : false),
         "SHOWARCHIVED" => ($_GET['showarchived'] == 1 ? true : false),
@@ -112,7 +114,59 @@ if (count($sortArray) == 2) {
 $DBLIB->orderBy("assetTypes.assetTypes_name", "ASC"); // Last item in the sort each time
 
 //Keywords
-if (count($SEARCH['TERMS']['KEYWORDS']) > 0) {
+if ($SEARCH['SIMPLE']) {
+    // Broad AssetType keyword match: name, description, manufacturer, category name,
+    // category-group name, and physical-asset tag. Each whitespace-separated term must
+    // match somewhere.
+    if ($SEARCH['SIMPLE_KEYWORD'] !== '') {
+        // Keep every non-empty term (including the literal "0", which a callback-less
+        // array_filter() would wrongly drop), then bound the query by capping the number
+        // of terms and the length of each so a pathological input can't build a huge WHERE.
+        $terms = array_values(array_filter(
+            preg_split('/\s+/', $SEARCH['SIMPLE_KEYWORD']),
+            function ($t) { return strlen(trim((string)$t)) > 0; }
+        ));
+        $terms = array_slice($terms, 0, 10);
+        $terms = array_map(function ($t) { return substr($t, 0, 100); }, $terms);
+        if (count($terms) > 0) {
+            $instanceIdInt = intval($SEARCH['INSTANCE_ID']);
+            $keywordNow = date("Y-m-d H:i:s");
+            $andClauses = [];
+            $allValues = [];
+            foreach ($terms as $term) {
+                $like = '%' . $term . '%';
+                // Mirror the linked/archived constraints the main results query applies so a
+                // tag match can't surface a type whose matching asset is filtered out below.
+                $existsExtra = '';
+                $existsExtraValues = [];
+                if (!$SEARCH['SETTINGS']['SHOWARCHIVED']) {
+                    $existsExtra .= "\n                          AND (a2.assets_endDate IS NULL OR a2.assets_endDate >= ?)";
+                    $existsExtraValues[] = $keywordNow;
+                }
+                if (!$SEARCH['SETTINGS']['SHOWLINKED']) {
+                    $existsExtra .= "\n                          AND a2.assets_linkedTo IS NULL";
+                }
+                $andClauses[] = "(
+                    assetTypes.assetTypes_name LIKE ?
+                    OR assetTypes.assetTypes_description LIKE ?
+                    OR manufacturers.manufacturers_name LIKE ?
+                    OR assetCategories.assetCategories_name LIKE ?
+                    OR assetCategoriesGroups.assetCategoriesGroups_name LIKE ?
+                    OR EXISTS (
+                        SELECT 1 FROM assets a2
+                        WHERE a2.assetTypes_id = assetTypes.assetTypes_id
+                          AND a2.instances_id = ?
+                          AND a2.assets_deleted = 0
+                          AND a2.assets_tag LIKE ?" . $existsExtra . "
+                    )
+                )";
+                array_push($allValues, $like, $like, $like, $like, $like, $instanceIdInt, $like);
+                foreach ($existsExtraValues as $ev) $allValues[] = $ev;
+            }
+            $DBLIB->where('(' . implode(' AND ', $andClauses) . ')', $allValues);
+        }
+    }
+} elseif (count($SEARCH['TERMS']['KEYWORDS']) > 0) {
     $thisWhere = false;
     $thisValues = [];
     foreach ($SEARCH['TERMS']['KEYWORDS'] as $word) {

--- a/src/assets.php
+++ b/src/assets.php
@@ -25,6 +25,7 @@ $SEARCH = [
         "SHOWLINKED" => ($_GET['showlinked'] == 1 ? true : false),
         "SHOWARCHIVED" => ($_GET['showarchived'] == 1 ? true : false),
         "HIDEIMAGES" => ($_GET['hideimages'] == 1 ? true : false),
+        "SHOWGROUPS" => (!isset($_GET['showgroups']) || $_GET['showgroups'] == '1'),
     ],
     "TERMS" => [
         "CATEGORY" => is_array($_GET['category']) ? $_GET['category'] : [],
@@ -52,6 +53,37 @@ $RETURN = [
         "NAME" => false
     ]
 ];
+
+/**
+ * Enrich one physical asset row with everything an asset list needs to render it: whether it
+ * clashes with another project over the search date range, and any maintenance flags/blocks.
+ * Shared by the assetTypes results loop and the asset group loop so the two stay in step.
+ */
+function hydrateAssetRow($tag, $dateStart, $dateEnd, $projectId) {
+    global $DBLIB;
+    $tag['assignment'] = false;
+    if ($dateStart and $dateEnd) {
+        //Check availability
+        $DBLIB->where("assets_id", $tag['assets_id']);
+        $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
+        $DBLIB->join("projects", "assetsAssignments.projects_id=projects.projects_id", "LEFT");
+        $DBLIB->where("projects.projects_deleted", 0);
+        // Standard date-range overlap: the assignment's project overlaps the search window
+        // when it starts on/before the window ends and ends on/after the window starts.
+        // Bound parameters only - never interpolate values into the SQL string.
+        $rangeStart = date("Y-m-d H:i:s", $dateStart);
+        $rangeEnd = date("Y-m-d H:i:s", $dateEnd);
+        $DBLIB->where("(projects_dates_deliver_start <= ? AND projects_dates_deliver_end >= ?)", [$rangeEnd, $rangeStart]);
+        $DBLIB->join("projectsStatuses", "projects.projectsStatuses_id=projectsStatuses.projectsStatuses_id", "LEFT");
+        if ($projectId) {
+            // If a project is being searched for specifically then we need to check if the asset is assigned to that project or if it is assigned to another project
+            $DBLIB->where("(projectsStatuses.projectsStatuses_assetsReleased = 0 OR projects.projects_id = ?)", [$projectId]);
+        } else $DBLIB->where("projectsStatuses.projectsStatuses_assetsReleased", 0);
+        $tag['assignment'] = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assetsAssignments_id", "assetsAssignments.projects_id", "projects.projects_name"]);
+    }
+    $tag['flagsblocks'] = assetFlagsAndBlocks($tag['assets_id']);
+    return $tag;
+}
 
 $DBLIB->where("instances_id",$SEARCH['INSTANCE_ID']);
 $DBLIB->where("instances_deleted",0);
@@ -269,27 +301,117 @@ foreach ($assets as $asset) {
     $asset['thumbnail'] = $bCMS->s3List(2, $asset['assetTypes_id'],'s3files_meta_uploaded','ASC',1);
     $asset['tags'] = [];
     foreach ($assetTags as $tag) {
-        if ($dateStart and $dateEnd) {
-            //Check availability
-            $DBLIB->where("assets_id", $tag['assets_id']);
-            $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
-            $DBLIB->join("projects", "assetsAssignments.projects_id=projects.projects_id", "LEFT");
-            $DBLIB->where("projects.projects_deleted", 0);
-            $DBLIB->where("((projects_dates_deliver_start >= '" . date ("Y-m-d H:i:s",$dateStart)  . "' AND projects_dates_deliver_start <= '" . date ("Y-m-d H:i:s",$dateEnd) . "') OR (projects_dates_deliver_end >= '" . date ("Y-m-d H:i:s",$dateStart) . "' AND projects_dates_deliver_end <= '" . date ("Y-m-d H:i:s",$dateEnd) . "') OR (projects_dates_deliver_end >= '" . date ("Y-m-d H:i:s",$dateEnd) . "' AND projects_dates_deliver_start <= '" . date ("Y-m-d H:i:s",$dateStart) . "'))");
-            $DBLIB->join("projectsStatuses", "projects.projectsStatuses_id=projectsStatuses.projectsStatuses_id", "LEFT");
-            if ($RETURN['PROJECT']['ID']) {
-                // If a project is being searched for specifically then we need to check if the asset is assigned to that project or if it is assigned to another project
-                $DBLIB->where("(projectsStatuses.projectsStatuses_assetsReleased = 0 OR projects.projects_id = '" . $RETURN['PROJECT']['ID'] . "')");
-            } else $DBLIB->where("projectsStatuses.projectsStatuses_assetsReleased", 0);
-            $tag['assignment'] = $DBLIB->get("assetsAssignments", null, ["assetsAssignments.assetsAssignments_id", "assetsAssignments.projects_id", "projects.projects_name"]);
-        }
-        $tag['flagsblocks'] = assetFlagsAndBlocks($tag['assets_id']);
+        $tag = hydrateAssetRow($tag, $dateStart, $dateEnd, $RETURN['PROJECT']['ID']);
         if ($tag['assignment'] or $tag['flagsblocks']['COUNT']['BLOCK'] > 0) $asset['countBlocked']++;
         $asset['tags'][] = $tag;
     }
     $asset['countAvailable'] = $asset['count'] - $asset['countBlocked'];
     $RETURN['ASSETS'][] = $asset;
 }
+//**ASSET GROUPS**
+// Asset Groups are shown as extra result cards mixed in with the asset types (gated by the
+// "Show asset groups" scope toggle). With a project selected they can be booked - a whole group
+// or picked apart - without leaving the search; with no project the cards are informational.
+// When the advanced Group filter names specific groups, exactly those are shown (the keyword is
+// ignored for cards); otherwise groups match on the search text. Page 1 only, because the
+// pagination above counts assetTypes rows and there is no page for a second stream to spill onto.
+$RETURN['GROUP_COUNT'] = 0;
+if ($SEARCH['SETTINGS']['SHOWGROUPS']
+    and $SEARCH['INSTANCE_ID'] == $AUTH->data['instance']['instances_id'] // api/projects/assets/assign.php only resolves groups in the current instance
+    and $SEARCH['PAGE'] == 1) {
+
+    $selectedGroupIds = array_values(array_filter(array_map('intval', $SEARCH['TERMS']['GROUPS'])));
+    $groupTerms = $SEARCH['SIMPLE'] ?
+        ($SEARCH['SIMPLE_KEYWORD'] === '' ? [] : array_values(array_filter(preg_split('/\s+/', $SEARCH['SIMPLE_KEYWORD'])))) :
+        array_values(array_filter($SEARCH['TERMS']['KEYWORDS']));
+
+    $DBLIB->where("(assetGroups.users_userid IS NULL OR assetGroups.users_userid = ?)", [$AUTH->data['users_userid']]);
+    $DBLIB->where("assetGroups.instances_id", $SEARCH['INSTANCE_ID']);
+    $DBLIB->where("assetGroups.assetGroups_deleted", 0);
+    if (count($selectedGroupIds) > 0) {
+        // Advanced Group filter names specific groups - show exactly those, ignore the keyword.
+        $DBLIB->where("assetGroups.assetGroups_id", $selectedGroupIds, "IN");
+    } elseif (count($groupTerms) > 0) {
+        // Every term must match either the group itself or one of the assets inside it
+        $andClauses = [];
+        $allValues = [];
+        foreach ($groupTerms as $term) {
+            $like = '%' . $term . '%';
+            $andClauses[] = "(
+                assetGroups.assetGroups_name LIKE ?
+                OR assetGroups.assetGroups_description LIKE ?
+                OR EXISTS (
+                    SELECT 1 FROM assets a3
+                    LEFT JOIN assetTypes at3 ON a3.assetTypes_id = at3.assetTypes_id
+                    LEFT JOIN manufacturers m3 ON at3.manufacturers_id = m3.manufacturers_id
+                    LEFT JOIN assetCategories ac3 ON at3.assetCategories_id = ac3.assetCategories_id
+                    WHERE FIND_IN_SET(assetGroups.assetGroups_id, a3.assets_assetGroups)
+                      AND a3.instances_id = ?
+                      AND a3.assets_deleted = 0
+                      AND (
+                        at3.assetTypes_name LIKE ?
+                        OR at3.assetTypes_description LIKE ?
+                        OR m3.manufacturers_name LIKE ?
+                        OR ac3.assetCategories_name LIKE ?
+                        OR a3.assets_tag LIKE ?
+                      )
+                )
+            )";
+            array_push($allValues, $like, $like, intval($SEARCH['INSTANCE_ID']), $like, $like, $like, $like, $like);
+        }
+        $DBLIB->where('(' . implode(' AND ', $andClauses) . ')', $allValues);
+    }
+    $DBLIB->orderBy("assetGroups.assetGroups_name", "ASC");
+    $matchedGroups = $DBLIB->get("assetGroups", 25, ["assetGroups_id", "assetGroups_name", "assetGroups_description", "users_userid"]);
+
+    $groupAssetBudget = 300; // Hydrating a member costs ~4 queries, so cap how many we render per page
+    $groupCards = [];
+    foreach ($matchedGroups as $group) {
+        $DBLIB->where("FIND_IN_SET(?, assets.assets_assetGroups)", [intval($group['assetGroups_id'])]);
+        $DBLIB->where("assets.instances_id", $SEARCH['INSTANCE_ID']);
+        $DBLIB->where("assets.assets_deleted", 0);
+        $DBLIB->join("assetTypes", "assets.assetTypes_id=assetTypes.assetTypes_id", "LEFT");
+        $DBLIB->orderBy("assetTypes.assetTypes_name", "ASC");
+        $DBLIB->orderBy("assets.assets_tag", "ASC");
+        $members = $DBLIB->get("assets", null, ["assets.assets_id", "assets.assets_tag", "assets.assetTypes_id", "assetTypes.assetTypes_name", "assets.assets_dayRate", "assets.assets_weekRate", "assetTypes.assetTypes_dayRate", "assetTypes.assetTypes_weekRate", "assets.assets_endDate", "assets.assets_notes"]);
+        if (!$members) continue; // An empty group is not worth a card
+
+        $card = [
+            "isGroup" => true,
+            "assetGroups_id" => $group['assetGroups_id'],
+            "assetGroups_name" => $group['assetGroups_name'],
+            "assetGroups_description" => $group['assetGroups_description'],
+            "personal" => $group['users_userid'] != null,
+            "count" => count($members),
+            "countBlocked" => 0,
+            "countAvailable" => 0,
+            "truncated" => false,
+            "tags" => [],
+        ];
+        if (count($members) > $groupAssetBudget) {
+            // Too big to list on this page - the card still offers "add the whole group",
+            // which is resolved entirely server side by the assign endpoint.
+            $card['truncated'] = true;
+        } else {
+            $groupAssetBudget -= count($members);
+            foreach ($members as $member) {
+                $member = hydrateAssetRow($member, $dateStart, $dateEnd, $RETURN['PROJECT']['ID']);
+                if ($member['assignment'] or $member['flagsblocks']['COUNT']['BLOCK'] > 0) $card['countBlocked']++;
+                $card['tags'][] = $member;
+            }
+        }
+        $card['countAvailable'] = $card['count'] - $card['countBlocked'];
+        $groupCards[] = $card;
+    }
+
+    if (count($groupCards) > 0) {
+        $RETURN['GROUP_COUNT'] = count($groupCards);
+        // Groups always lead the page, whatever the sort - they have no price/mass/value/date to
+        // sort against the asset types, and leading keeps them easy to find.
+        $RETURN['ASSETS'] = array_merge($groupCards, $RETURN['ASSETS']);
+    }
+}
+
 $RETURN['SPEED'] = microtime(true) - $scriptStartTime;
 
 
@@ -334,4 +456,5 @@ if (count($SEARCH['TERMS']['CATEGORY']) > 0) {
 
 $RETURN['SEARCH'] = $SEARCH;
 $PAGEDATA['searchResults'] = $RETURN;
+
 echo $TWIG->render('assets.twig', $PAGEDATA);

--- a/src/assets.twig
+++ b/src/assets.twig
@@ -17,6 +17,7 @@
             {% endfor %}
         {% endif %}
         <form method="get" action="{{CONFIG.ROOTURL}}/assets.php" id="assetSearchForm">
+            <input type="hidden" name="simple" id="assetSearchSimpleFlag" value="1">
             <div class="card">
                 <div class="card-header">
                     <h3 class="card-title">Assets</h3>
@@ -30,126 +31,146 @@
                 </div>
                 <div class="card-body">
                     <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
-                            <div class="form-group">
-                                <label>Keyword</label>
-                                <select class="form-control select2bs4" multiple="multiple" name="keyword[]">
-                                    {% for term in searchResults.SEARCH.TERMS.KEYWORDS %}
-                                        <option value="{{ term }}" selected>{{ term }}</option>
-                                    {% endfor %}
-                                </select>
-                                <small class="form-text text-muted">Seperate multiple keywords with a comma</small>
+                        <div class="col-12 col-lg-7">
+                            <div id="assetSearchSimpleField" class="form-group mb-2">
+                                <label for="assetSearchSimpleKeyword" class="mb-1">Keyword</label>
+                                <input type="text" id="assetSearchSimpleKeyword" name="simple_keyword" class="form-control" value="{{ searchResults.SEARCH.SIMPLE_KEYWORD }}" placeholder="Search assets by name, tag, category, manufacturer, group…" autocomplete="off">
+                                <small class="form-text text-muted">Searches asset name, description, tag, category, manufacturer and group.</small>
                             </div>
-                            <div class="form-group">
-                                <label>Tag</label>
-                                <select class="form-control select2bs4" multiple="multiple" name="tags[]">
-                                    {% for tag in searchResults.SEARCH.TERMS.TAGS %}
-                                        <option value="{{ tag }}" selected>{{ tag }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Manufacturer</label>
-                                <select class="form-control select2bs4" multiple name="manufacturer[]">
-                                    {% for manufacturer in searchResults.SEARCH['SELECTED_TERMS']['MANUFACTURER'] %}
-                                        <option value="{{ manufacturer.manufacturers_id }}" selected>{{ manufacturer.manufacturers_name }}</option>
-                                    {% endfor %}
-                                </select>
+                        </div>
+                        <div class="col-12 col-lg-5" id="assetSearchScopeBar">
+                            <div class="form-group mb-2">
+                                <label class="mb-0"><small class="text-muted">Business</small></label>
+                                <select class="form-control select2 select2bs4" name="instance_id">
+                                        {% for instance in USERDATA.instances %}
+                                            <option {{ searchResults.SEARCH.INSTANCE_ID == instance.instances_id ? 'selected' : '' }}  value="{{instance.instances_id}}">{{instance.instances_name}}</option>
+                                        {% endfor %}
+                                    </select>
                             </div>
                             
+                            
+                            <div class="form-row" id="assetSearchScopeInline">
+                                <div class="form-group col-auto mb-2" style="min-width:14rem;">
+                                    <label class="mb-0"><small class="text-muted">Sort by</small></label>
+                                    <select class="form-control select2 select2bs4" name="sort">
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "price-a" ? 'selected' : '' }}  value="price-a">Weekly Price (low-high)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "price-d" ? 'selected' : '' }}  value="price-d">Weekly Price (high-low)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "value-a" ? 'selected' : '' }}  value="value-a">Value (low-high)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "value-d" ? 'selected' : '' }}  value="value-d">Value (high-low)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "alphabet-a" ? 'selected' : '' }}  value="alphabet-a">Alphabetical (A-Z)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "alphabet-d" ? 'selected' : '' }}  value="alphabet-d">Alphabetical (Z-A)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "mass-a" ? 'selected' : '' }}  value="mass-a">Mass (low-high)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "mass-d" ? 'selected' : '' }}  value="mass-d">Mass (high-low)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "date-d" ? 'selected' : '' }}  value="date-d">Date Added (most recent first)</option>
+                                        <option {{ searchResults.SEARCH.TERMS.SORT == "date-a" ? 'selected' : '' }}  value="date-a">Date Added (oldest first)</option>
+                                    </select>
+                                </div>
+                                <div class="form-group col-auto mb-2" style="min-width:8rem;">
+                                    <label class="mb-0"><small class="text-muted">Per page</small></label>
+                                    <select class="form-control select2 select2bs4" name="resultsperpage">
+                                        <option {{ searchResults.SEARCH.PAGE_LIMIT == 10 ? 'selected' : '' }}>10</option>
+                                        <option {{ searchResults.SEARCH.PAGE_LIMIT == 20 ? 'selected' : '' }}>20</option>
+                                        <option {{ searchResults.SEARCH.PAGE_LIMIT == 50 ? 'selected' : '' }}>50</option>
+                                        <option {{ searchResults.SEARCH.PAGE_LIMIT == 100 ? 'selected' : '' }}>100</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="mb-1">
+                                <label class="d-block mb-1" style="font-weight:normal;"><input type="checkbox" name="hideimages" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.HIDEIMAGES ? "checked" : "" }}> Hide asset images</label>
+                            </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
-                            <div class="form-group">
-                                <label>Group</label>
-                                <select class="form-control select2bs4" name="group[]" multiple>
-                                    {% for group in searchResults.SEARCH['SELECTED_TERMS']['GROUPS'] %}
-                                        <option value="{{ group.assetGroups_id }}" selected>{{ group.assetGroups_name }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Category</label>
-                                <select class="form-control select2bs4" multiple name="category[]">
-                                    {% for category in searchResults.SEARCH['SELECTED_TERMS']['CATEGORY'] %}
-                                        <option value="{{ category.assetCategories_id }}" selected>{{ category.assetCategoriesGroups_name }} - {{ category.assetCategories_name }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Business</label>
-                                <select class="form-control select2 select2bs4" name="instance_id">
-                                    {% for instance in USERDATA.instances %}
-                                        <option {{ searchResults.SEARCH.INSTANCE_ID == instance.instances_id ? 'selected' : '' }}  value="{{instance.instances_id}}">{{instance.instances_name}}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        </div>
-                        <div class="col-12 col-md-6 col-lg-4">
-                            {% if "PROJECTS:PROJECT_ASSETS:CREATE:ASSIGN_AND_UNASSIGN"|instancePermissions %}
+                    </div>
+                    <div class="mb-2">
+                        <a href="#" id="assetSearchAdvancedToggle" role="button" aria-expanded="false" aria-controls="assetSearchAdvanced">
+                            <i class="fas fa-caret-right" id="assetSearchAdvancedToggleIcon"></i>
+                            <span id="assetSearchAdvancedToggleLabel">Advanced filters</span>
+                        </a>
+                    </div>
+                    <div id="assetSearchAdvanced" style="display:none;">
+                        <hr>
+                        <div class="row">
+                            <div class="col-12 col-md-6 col-lg-4">
                                 <div class="form-group">
-                                    <label>Project to assign assets to</label>
-                                    <select class="form-control select2 select2bs4" name="project">
-                                        <option value="">No project selected</option>
-                                        {% for project in searchOptions.projects %}
-                                            <option {{ searchResults.SEARCH.PROJECT_ID == project.projects_id ? 'selected' : '' }}  value="{{ project.projects_id }}">{{ project.projects_name }}{{ project.clients_name ? " | " ~ project.clients_name : "" }}</option>
+                                    <label>Tag</label>
+                                    <select class="form-control select2bs4" multiple="multiple" name="tags[]">
+                                        {% for tag in searchResults.SEARCH.TERMS.TAGS %}
+                                            <option value="{{ tag }}" selected>{{ tag }}</option>
                                         {% endfor %}
                                     </select>
                                 </div>
-                                {% if searchResults.SEARCH.PROJECT_ID == searchResults.SEARCH.PROJECT_REFERER %}
-                                    <input type="hidden" name="project_referer" value="{{ searchResults.SEARCH.PROJECT_REFERER }}">
+                                <div class="form-group">
+                                    <label>Manufacturer</label>
+                                    <select class="form-control select2bs4" multiple name="manufacturer[]">
+                                        {% for manufacturer in searchResults.SEARCH['SELECTED_TERMS']['MANUFACTURER'] %}
+                                            <option value="{{ manufacturer.manufacturers_id }}" selected>{{ manufacturer.manufacturers_name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+
+                            </div>
+                            <div class="col-12 col-md-6 col-lg-4">
+                                <div class="form-group">
+                                    <label>Group</label>
+                                    <select class="form-control select2bs4" name="group[]" multiple>
+                                        {% for group in searchResults.SEARCH['SELECTED_TERMS']['GROUPS'] %}
+                                            <option value="{{ group.assetGroups_id }}" selected>{{ group.assetGroups_name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label>Category</label>
+                                    <select class="form-control select2bs4" multiple name="category[]">
+                                        {% for category in searchResults.SEARCH['SELECTED_TERMS']['CATEGORY'] %}
+                                            <option value="{{ category.assetCategories_id }}" selected>{{ category.assetCategoriesGroups_name }} - {{ category.assetCategories_name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                                
+                            </div>
+                            <div class="col-12 col-md-6 col-lg-4">
+                                {% if "PROJECTS:PROJECT_ASSETS:CREATE:ASSIGN_AND_UNASSIGN"|instancePermissions %}
+                                    <div class="form-group">
+                                        <label>Project to assign assets to</label>
+                                        <select class="form-control select2 select2bs4" name="project">
+                                            <option value="">No project selected</option>
+                                            {% for project in searchOptions.projects %}
+                                                <option {{ searchResults.SEARCH.PROJECT_ID == project.projects_id ? 'selected' : '' }}  value="{{ project.projects_id }}">{{ project.projects_name }}{{ project.clients_name ? " | " ~ project.clients_name : "" }}</option>
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                    {% if searchResults.SEARCH.PROJECT_ID == searchResults.SEARCH.PROJECT_REFERER %}
+                                        <input type="hidden" name="project_referer" value="{{ searchResults.SEARCH.PROJECT_REFERER }}">
+                                    {% endif %}
+                                {% else %}
+                                <div class="form-group">
+                                    <label>Show availability between</label>
+                                    <input type="text" class="form-control" name="dates" value="{{ searchResults.SEARCH.TERMS['DATE-START'] ? searchResults.SEARCH.TERMS['DATE-START'] ~ " - " ~ searchResults.SEARCH.TERMS['DATE-END'] }}" />
+                                </div>
                                 {% endif %}
-                            {% else %}
-                            <div class="form-group">
-                                <label>Show availability between</label>
-                                <input type="text" class="form-control" name="dates" value="{{ searchResults.SEARCH.TERMS['DATE-START'] ? searchResults.SEARCH.TERMS['DATE-START'] ~ " - " ~ searchResults.SEARCH.TERMS['DATE-END'] }}" />
-                            </div>
-                            {% endif %}
-                            <div class="form-group">
-                                <label>Number of results per page</label>
-                                <select class="form-control select2 select2bs4" name="resultsperpage">
-                                    <option {{ searchResults.SEARCH.PAGE_LIMIT == 10 ? 'selected' : '' }}>10</option>
-                                    <option {{ searchResults.SEARCH.PAGE_LIMIT == 20 ? 'selected' : '' }}>20</option>
-                                    <option {{ searchResults.SEARCH.PAGE_LIMIT == 50 ? 'selected' : '' }}>50</option>
-                                    <option {{ searchResults.SEARCH.PAGE_LIMIT == 100 ? 'selected' : '' }}>100</option>
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Sort by</label>
-                                <select class="form-control select2 select2bs4" name="sort">
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "price-a" ? 'selected' : '' }}  value="price-a">Weekly Price (low-high)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "price-d" ? 'selected' : '' }}  value="price-d">Weekly Price (high-low)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "value-a" ? 'selected' : '' }}  value="value-a">Value (low-high)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "value-d" ? 'selected' : '' }}  value="value-d">Value (high-low)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "alphabet-a" ? 'selected' : '' }}  value="alphabet-a">Alphabetical (A-Z)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "alphabet-d" ? 'selected' : '' }}  value="alphabet-d">Alphabetical (Z-A)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "mass-a" ? 'selected' : '' }}  value="mass-a">Mass (low-high)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "mass-d" ? 'selected' : '' }}  value="mass-d">Mass (high-low)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "date-d" ? 'selected' : '' }}  value="date-d">Date Added (most recent first)</option>
-                                    <option {{ searchResults.SEARCH.TERMS.SORT == "date-a" ? 'selected' : '' }}  value="date-a">Date Added (oldest first)</option>
-                                </select>
-                            </div>
-                            <div class="mb-1">
-                                <input type="checkbox" name="showlinked" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.SHOWLINKED ? "checked" : "" }}>
-                                <span>Show assets linked to others</span>
-                            </div>
-                            <div class="mb-1">
-                                <input type="checkbox" name="showarchived" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.SHOWARCHIVED ? "checked" : "" }}>
-                                <span>Show archived assets</span>
-                            </div>
-                            <div class="mb-1">
-                                <input type="checkbox" name="hideimages" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.HIDEIMAGES ? "checked" : "" }}>
-                                <span>Hide asset images</span>
+                                <div class="form-group">
+                                    <label class="d-block mb-1" style="font-weight:normal;"><input type="checkbox" name="showlinked" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.SHOWLINKED ? "checked" : "" }}> Show assets linked to others</label>
+                                    <label class="d-block mb-1" style="font-weight:normal;"><input type="checkbox" name="showarchived" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.SHOWARCHIVED ? "checked" : "" }}> Show archived assets</label>
+                                </div>
+                                
+                                
+                                
+                                
+                                
                             </div>
                         </div>
                     </div>
                 </div>
-                <div class="card-footer">
+                <div class="card-footer" id="assetSearchAdvancedFooter" style="display:none;">
                     <button type="submit" class="btn btn-primary btn-lg ">Search</button>
                 </div>
             </div>
         </form>
     </div>
-    <div class="col-12">
+    <div class="col-12" style="position:relative;">
+        <div id="assetSearchLoading" style="display:none;position:absolute;inset:0;z-index:10;background:rgba(255,255,255,0.55);text-align:center;padding-top:60px;">
+            <i class="fas fa-spinner fa-spin fa-2x text-primary"></i>
+        </div>
+        <div id="assetSearchResults">
         {% if searchResults.ASSETS %}
         <div class="card card-solid">
             <div class="card-header">
@@ -438,6 +459,7 @@
             </div>
         </div>
         {% endif %}
+        </div>
     </div>
 </div>
 <script>
@@ -448,7 +470,217 @@ function replaceQueryParam(param, newval, search) {
     return (query.length > 2 ? query + "&" : "?") + (newval ? param + "=" + newval : '');
 }
 $(document).ready(function () {
-    $('#assetSearchForm input[name ="dates"]').daterangepicker({
+    var $form = $('#assetSearchForm');
+    var $simpleField = $('#assetSearchSimpleField');
+    var $simpleKeyword = $('#assetSearchSimpleKeyword');
+    var $simpleFlag = $('#assetSearchSimpleFlag');
+    var $advancedSection = $('#assetSearchAdvanced');
+    var $advancedFooter = $('#assetSearchAdvancedFooter');
+    var $advancedToggle = $('#assetSearchAdvancedToggle');
+    var $advancedToggleIcon = $('#assetSearchAdvancedToggleIcon');
+    var $advancedToggleLabel = $('#assetSearchAdvancedToggleLabel');
+    var $results = $('#assetSearchResults');
+    var $loading = $('#assetSearchLoading');
+
+    // Fields that represent action-context (not result-filters) and must survive
+    // the collapse/simple-mode wipe. `project` is the target for "add to project"
+    // buttons on each result card; `project_referer` is its paired hidden marker.
+    var ADVANCED_EXEMPT_FROM_RESET = { 'project': 1, 'project_referer': 1 };
+
+    // Reset every Advanced-section field (the content filters: keyword, tags,
+    // manufacturer, group, category, dates) to its HTML-default value. Called on
+    // collapse and on initial load so a hidden filter can never silently influence a
+    // simple search. Scope controls (business, sort, per-page, the checkboxes) live in
+    // the always-visible bar outside this section and are deliberately NOT reset here.
+    // Uses defaultSelected/defaultChecked/defaultValue instead of the browser's
+    // first-option pick.
+    function resetAdvancedFields() {
+        $advancedSection.find('input, select, textarea').each(function () {
+            var el = this;
+            if (el.name && ADVANCED_EXEMPT_FROM_RESET[el.name]) return;
+            if (el.type === 'checkbox' || el.type === 'radio') {
+                el.checked = el.defaultChecked;
+            } else if (el.tagName === 'SELECT') {
+                var anyDefault = false;
+                $(el).find('option').each(function () {
+                    this.selected = this.defaultSelected;
+                    if (this.defaultSelected) anyDefault = true;
+                });
+                // If no option had `selected` in the HTML, force nothing selected
+                // (rather than letting the browser keep its first-option pick alive).
+                if (!anyDefault && !el.multiple) {
+                    el.selectedIndex = -1;
+                }
+                // .select2 namespace refreshes select2's UI without firing our
+                // top-level `change` handler (which would re-trigger a search).
+                $(el).trigger('change.select2');
+            } else {
+                el.value = el.defaultValue;
+            }
+        });
+    }
+
+    // Advanced always starts collapsed — deliberately do not persist state.
+    var advancedOpen = false;
+    function applyAdvancedVisibility() {
+        if (advancedOpen) {
+            $advancedSection.show();
+            $advancedFooter.show();
+            $advancedToggleIcon.removeClass('fa-caret-right').addClass('fa-caret-down');
+            $advancedToggleLabel.text('Hide advanced filters');
+            $advancedToggle.attr('aria-expanded', 'true');
+        } else {
+            $advancedSection.hide();
+            $advancedFooter.hide();
+            $advancedToggleIcon.removeClass('fa-caret-down').addClass('fa-caret-right');
+            $advancedToggleLabel.text('Advanced filters');
+            $advancedToggle.attr('aria-expanded', 'false');
+            // Clear the advanced content filters when hiding them, so a filter left
+            // set in a collapsed panel can never silently narrow the search. The
+            // keyword box and scope bar sit outside the panel and stay put.
+            resetAdvancedFields();
+        }
+    }
+    applyAdvancedVisibility();
+    $advancedToggle.on('click', function (e) {
+        e.preventDefault();
+        advancedOpen = !advancedOpen;
+        applyAdvancedVisibility();
+        // Do not trigger a search — visibility toggle only.
+    });
+
+    // --- Auto-search machinery ---------------------------------------------
+    var debounceTimer = null;
+    var currentAbort = null;
+
+    // Strict allow-lists per mode. Anything not in the active mode's list is dropped
+    // from the URL, so a hidden/stale DOM value in the other mode can never
+    // silently influence the search backend receives.
+    //
+    // `project` / `project_referer` appear in BOTH lists — they're action-context
+    // (target for "add to project" on each result card), not a result filter, and
+    // must reach the backend regardless of collapse state so the buttons work.
+    // One query shape: the keyword box + scope bar always search, and the Advanced
+    // filters (tag/manufacturer/group/category/dates) combine on top. keyword[] is
+    // intentionally absent - the single keyword box above replaces it.
+    var QUERY_ALLOW = {
+        'simple': 1, 'simple_keyword': 1, 'page': 1,
+        'project': 1, 'project_referer': 1,
+        'instance_id': 1, 'resultsperpage': 1, 'sort': 1,
+        'showlinked': 1, 'showarchived': 1, 'hideimages': 1,
+        'tags[]': 1, 'manufacturer[]': 1, 'group[]': 1, 'category[]': 1, 'dates': 1,
+    };
+
+    function buildQueryString(overridePage) {
+        var params = new URLSearchParams();
+        var allow = QUERY_ALLOW;
+        $form.find('input, select, textarea').each(function () {
+            var el = this;
+            var name = el.name;
+            if (!name || !allow[name]) return;
+            if (el.type === 'checkbox' || el.type === 'radio') {
+                if (el.checked) params.append(name, el.value);
+                return;
+            }
+            if (el.tagName === 'SELECT' && el.multiple) {
+                $(el).find('option:selected').each(function () {
+                    params.append(name, this.value);
+                });
+                return;
+            }
+            var val = el.value;
+            if (val === '' || val == null) return;
+            params.append(name, val);
+        });
+        if (overridePage != null) {
+            params.delete('page');
+            params.append('page', overridePage);
+        }
+        return params.toString();
+    }
+
+    function runSearch(overridePage) {
+        if (currentAbort) {
+            currentAbort.abort();
+        }
+        var qs = buildQueryString(overridePage);
+        var url = "{{ CONFIG.ROOTURL }}/assets.php?" + qs;
+        currentAbort = new AbortController();
+        $loading.stop(true, true).fadeIn(80);
+        fetch(url, {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            credentials: 'same-origin',
+            signal: currentAbort.signal
+        }).then(function (r) {
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            return r.text();
+        }).then(function (html) {
+            var doc = new DOMParser().parseFromString(html, 'text/html');
+            var next = doc.getElementById('assetSearchResults');
+            if (!next) throw new Error('No results block in response');
+            // Preserve the overlay element by swapping only inner content.
+            $results.html(next.innerHTML);
+            // Rebind carousels inside the new results.
+            $results.find('.slick').slick({
+                dots: false,
+                arrows: false,
+                focusOnSelect: true,
+                pauseOnHover: true,
+                draggable: false,
+                infinite: true,
+                slidesToShow: 1,
+                slidesToScroll: 1,
+                autoplay: true,
+                autoplaySpeed: 2000,
+            });
+            // Update URL (without page reload) so bookmarks / refresh work.
+            history.replaceState(null, '', window.location.pathname + '?' + qs);
+        }).catch(function (err) {
+            if (err.name === 'AbortError') return;
+            console.error('Asset search failed', err);
+        }).finally(function () {
+            $loading.stop(true, true).fadeOut(120);
+        });
+    }
+
+    function scheduleSearch(delayMs) {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(function () {
+            debounceTimer = null;
+            runSearch(1); // any filter change resets to page 1
+        }, delayMs);
+    }
+
+    // Debounced input on the simple keyword field.
+    $simpleKeyword.on('input', function () { scheduleSearch(500); });
+
+    // Immediate change on the always-visible scope bar (business, sort, per-page,
+    // the three checkboxes) - applies in both quick and advanced mode.
+    $('#assetSearchScopeBar').on('change', 'input, select', function () {
+        scheduleSearch(0);
+    });
+
+    // Immediate change on every advanced filter control.
+    $advancedSection.on('change', 'input, select, textarea', function () {
+        // Skip when the change is on the daterangepicker's internal state (we
+        // already listen for apply/cancel separately).
+        scheduleSearch(0);
+    });
+
+    // Manual search button — submit fires immediately, cancelling any pending.
+    $form.on('submit', function (e) {
+        e.preventDefault();
+        if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+        runSearch(1);
+    });
+
+    // Pagination — swap results instead of full navigation.
+    $(document).on('click', '#assetSearchResults .page-link[data-page]', function (e) {
+        e.preventDefault();
+        runSearch($(this).data('page'));
+    });
+
+    $form.find('input[name ="dates"]').daterangepicker({
         timePicker: true,
         timePickerIncrement: 15,
         locale: {
@@ -458,22 +690,15 @@ $(document).ready(function () {
     });
     $('#assetSearchForm input[name ="dates"]').on('apply.daterangepicker', function(ev, picker) {
         $(this).val(picker.startDate.format('DD MMM YYYY hh:mm A') + ' - ' + picker.endDate.format('DD MMM YYYY hh:mm A'));
+        scheduleSearch(0);
     });
     $('#assetSearchForm input[name ="dates"]').on('cancel.daterangepicker', function(ev, picker) {
         $(this).val('');
+        scheduleSearch(0);
     });
     $('#assetSearchForm .select2').select2({
         theme: "bootstrap4",
         width: '100%'
-    });
-    $('#assetSearchForm select[name ="keyword[]"]').select2({
-        tags: true,
-        tokenSeparators: [',', ';'],
-        multiple: true,
-        theme: "bootstrap4",
-        minimumInputLength: 1,
-        width: '100%',
-        placeholder: "SD7T, Viper, Wash, Condenser, CYC, Dynamic, Clamp",
     });
     $('#assetSearchForm select[name ="tags[]"]').select2({
         tags: true,
@@ -591,11 +816,6 @@ $(document).ready(function () {
             }
         }
     });
-    $(document).on("click",".page-link[data-page]",function () {
-        var str = window.location.search
-        str = replaceQueryParam('page', $(this).data("page"), str)
-        window.location = window.location.pathname + str
-    });
     const Toast = Swal.mixin({
         toast: true,
         position: 'top-end',
@@ -615,21 +835,39 @@ $(document).ready(function () {
         autoplaySpeed: 2000,
     });
     {% if searchResults.PROJECT.ID != null and "PROJECTS:PROJECT_ASSETS:CREATE:ASSIGN_AND_UNASSIGN"|instancePermissions %}
-    $(".addToBasketAssetButton").click(function () {
-        var assetId=$(this).data("assetid");
-        ajaxcall("projects/assets/assign.php", {"assets_id":$(this).data("assetid"),"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
+    // Read the CURRENTLY selected project at click time. Auto-search swaps only the
+    // results container, not this outer script, so a project id baked in at page load
+    // would go stale the moment the user changes the project selector and cause
+    // assignments to POST to the wrong project.
+    function currentProjectId() {
+        var $sel = $('#assetSearchForm select[name="project"]');
+        if ($sel.length) return $sel.val() || '';
+        return "{{ searchResults.SEARCH.PROJECT_ID }}";
+    }
+    function currentProjectName() {
+        var $sel = $('#assetSearchForm select[name="project"]');
+        if ($sel.length && $sel.val()) {
+            // Option labels are rendered as "Project name | Client"; keep the name half.
+            return ($sel.find('option:selected').text().split(' | ')[0] || '').trim();
+        }
+        return "{{ searchResults.PROJECT.NAME }}";
+    }
+    // Delegated so that DOM swaps from auto-search don't detach these handlers.
+    $(document).on('click', '#assetSearchResults .addToBasketAssetButton', function () {
+        var assetId = $(this).data("assetid");
+        ajaxcall("projects/assets/assign.php", {"assets_id":assetId,"projects_id":currentProjectId()}, function (data) {
             $(".addToBasketAssetButton[data-assetid=" + assetId + "]").hide();
             $(".removeFromBasketAssetButton[data-assetid=" + assetId + "]").show();
             Toast.fire({
                 type: 'success',
-                title: 'Added to {{ searchResults.PROJECT.NAME }}'
+                title: 'Added to ' + currentProjectName()
             });
         });
     });
-    $(".addToBasketAssetTypeButton").click(function () {
+    $(document).on('click', '#assetSearchResults .addToBasketAssetTypeButton', function () {
         const thisButton = $(this);
         var assetTypeId = thisButton.data("assettypeid");
-        ajaxcall("projects/assets/assign.php", {"assetTypes_id":assetTypeId,"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
+        ajaxcall("projects/assets/assign.php", {"assetTypes_id":assetTypeId,"projects_id":currentProjectId()}, function (data) {
             var failedIds = (data.response && data.response.failed ? data.response.failed : []).map(function(f) { return f.assets_id; });
             $(".addToBasketAssetButton[data-assettypeid=" + assetTypeId + "]").each(function() {
                 var assetId = $(this).data("assetid");
@@ -641,11 +879,11 @@ $(document).ready(function () {
             thisButton.prop('disabled', true);
             Toast.fire({
                 type: 'success',
-                title: 'Added to {{ searchResults.PROJECT.NAME }}'
+                title: 'Added to ' + currentProjectName()
             });
         });
     });
-    $(".removeFromBasketAssetButton").click(function () {
+    $(document).on('click', '#assetSearchResults .removeFromBasketAssetButton', function () {
         var assetId = $(this).data("assetid");
         bootbox.confirm({
             message: "Are you sure you wish to remove this asset from the project?",
@@ -661,12 +899,12 @@ $(document).ready(function () {
             },
             callback: function (result) {
                 if (result) {
-                    ajaxcall("projects/assets/unassign.php", {"assets_id":assetId,"projects_id":"{{ searchResults.SEARCH.PROJECT_ID }}"}, function (data) {
+                    ajaxcall("projects/assets/unassign.php", {"assets_id":assetId,"projects_id":currentProjectId()}, function (data) {
                         $(".addToBasketAssetButton[data-assetid=" + assetId + "]").show();
                         $(".removeFromBasketAssetButton[data-assetid=" + assetId + "]").hide();
                         Toast.fire({
                             type: 'success',
-                            title: 'Removed from {{ searchResults.PROJECT.NAME }}'
+                            title: 'Removed from ' + currentProjectName()
                         });
                     });
                 }

--- a/src/assets.twig
+++ b/src/assets.twig
@@ -76,6 +76,8 @@
                                 </div>
                             </div>
                             <div class="mb-1">
+                                {# Hidden companion so an unchecked box still posts showgroups=0; the box defaults on. #}
+                                <label class="d-block mb-1" style="font-weight:normal;"><input type="hidden" name="showgroups" value="0"><input type="checkbox" name="showgroups" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.SHOWGROUPS ? "checked" : "" }}> Show asset groups</label>
                                 <label class="d-block mb-1" style="font-weight:normal;"><input type="checkbox" name="hideimages" value="1" class="mr-1" {{ searchResults.SEARCH.SETTINGS.HIDEIMAGES ? "checked" : "" }}> Hide asset images</label>
                             </div>
                         </div>
@@ -175,7 +177,7 @@
         <div class="card card-solid">
             <div class="card-header">
                 <h3 class="card-title" style="margin-top: 0.4rem;">
-                    Showing {{ searchResults.PAGINATION.OFFSET>0 ? 'results ' ~ searchResults.PAGINATION.OFFSET ~ '-' ~ (searchResults.PAGINATION.OFFSET+(searchResults.ASSETS|length)) : searchResults.ASSETS|length }} of {{ searchResults.PAGINATION.COUNT }} result{{ searchResults.PAGINATION.COUNT == 1 ? '' : 's' }} found in {{ searchResults.SPEED|round(1) }} second{{ searchResults.SPEED|round(1) != 1 ? 's':'' }}
+                    Showing {{ searchResults.PAGINATION.OFFSET>0 ? 'results ' ~ searchResults.PAGINATION.OFFSET ~ '-' ~ (searchResults.PAGINATION.OFFSET+(searchResults.ASSETS|length - searchResults.GROUP_COUNT)) : (searchResults.ASSETS|length - searchResults.GROUP_COUNT) }} of {{ searchResults.PAGINATION.COUNT }} result{{ searchResults.PAGINATION.COUNT == 1 ? '' : 's' }}{% if searchResults.GROUP_COUNT > 0 %} and {{ searchResults.GROUP_COUNT }} group{{ searchResults.GROUP_COUNT == 1 ? '' : 's' }}{% endif %} found in {{ searchResults.SPEED|round(1) }} second{{ searchResults.SPEED|round(1) != 1 ? 's':'' }}
                 </h3>
                 <div class="card-tools pull-right">
                 {% if searchResults.PAGINATION['TOTAL-PAGES'] > 1 %}
@@ -203,6 +205,99 @@
             <div class="card-body">
                 <div class="row d-flex align-items-stretch">
                     {% for asset in searchResults.ASSETS %}
+                        {% if asset.isGroup %}
+                            {# Asset Group pseudo-result. The booking controls (the whole-group dolly and per-member baskets) only render when a project is selected; with no project the card is informational. #}
+                            <div class="col-auto d-flex align-items-stretch" style="padding: 10px;">
+                                <div class="card">
+                                    <div class="card-body" style="max-width: 250px;">
+                                        <h2 class="lead"><span class="badge badge-info">Group</span> <b>{{ asset.assetGroups_name }}</b></h2>
+                                        <p class="text-muted text-sm">{{ asset.assetGroups_description|length > 60 ? (asset.assetGroups_description|slice(0, 60) ~ '...')|nl2br : asset.assetGroups_description|nl2br }}</p>
+                                        <ul class="ml-4 mb-0 fa-ul text-muted">
+                                            <li class="small"><span class="fa-li"><i class="fas fa-object-group"></i></span> Asset Group{{ asset.personal ? ' (visible only to me)' : '' }}</li>
+                                            <li class="small" title="Assets in this group"><span class="fa-li"><i class="fas fa-boxes"></i></span> {{ asset.count }} asset{{ asset.count == 1 ? '' : 's' }}{% if not asset.truncated %} &middot; {{ asset.countAvailable }} available{% endif %}</li>
+                                        </ul>
+                                    </div>
+                                    <div class="card-footer">
+                                        <div class="text-right">
+                                            <div class="btn-group">
+                                                <div class="modal fade" id="assetGroupDetailsModal{{ asset.assetGroups_id }}">
+                                                    <div class="modal-dialog modal-xl">
+                                                        <div class="modal-content">
+                                                            <div class="modal-header">
+                                                                <h4 class="modal-title">Group: {{ asset.assetGroups_name }}</h4>
+                                                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                                    <span aria-hidden="true">&times;</span>
+                                                                </button>
+                                                            </div>
+                                                            <div class="modal-body" style="padding:0;text-align:left;overflow-x: auto;">
+                                                                <table class="table table-striped">
+                                                                    <tr>
+                                                                        <th>ID</th>
+                                                                        <th>Asset Type</th>
+                                                                        <th>Notes</th>
+                                                                        <th>Cost/day</th>
+                                                                        <th>Cost/week</th>
+                                                                        <th style="width:1%"><i class="fas fa-flag"></i></th>
+                                                                        {% if searchResults.PROJECT.ID %}
+                                                                        <th style="width:30px;">
+                                                                            <button class="btn btn-success addToBasketGroupButton" {% if asset.countAvailable < 1 %}disabled{% endif %} title="Add every asset in this group to the project" data-assetGroupId="{{ asset.assetGroups_id }}"><i class="fas fa-dolly"></i></button>
+                                                                        </th>
+                                                                        {% endif %}
+                                                                    </tr>
+                                                                    {% if asset.truncated %}
+                                                                        <tr>
+                                                                            <td colspan="{{ searchResults.PROJECT.ID ? 7 : 6 }}" class="text-muted">This group holds too many assets to list here &mdash; open it from the Groups page{% if searchResults.PROJECT.ID %}, or use the <i class="fas fa-dolly"></i> button to add them all{% endif %}.</td>
+                                                                        </tr>
+                                                                    {% endif %}
+                                                                    {% for thisasset in asset.tags %}
+                                                                        <tr>
+                                                                            <td>{{ thisasset.assets_tag|aTag }}</td>
+                                                                            <td>{{ thisasset.assetTypes_name }}</td>
+                                                                            <td>{{ thisasset['assets_notes']|nl2br }}</td>
+                                                                            <td>
+                                                                                {{ (thisasset.assets_dayRate ?: thisasset.assetTypes_dayRate)|money(searchResults.SEARCH.INSTANCE['instances_config_currency']) }}
+                                                                            </td>
+                                                                            <td>
+                                                                                {{ (thisasset.assets_weekRate ?: thisasset.assetTypes_weekRate)|money(searchResults.SEARCH.INSTANCE['instances_config_currency']) }}
+                                                                            </td>
+                                                                            <td>
+                                                                                {{ thisasset.flagsblocks.COUNT.FLAG > 0 ?: '' }}
+                                                                            </td>
+                                                                            {% if searchResults.PROJECT.ID %}
+                                                                            <td>
+                                                                                {# data-assetTypeId and data-assetGroupId are both carried so the "add all of this type" and "add whole group" handlers keep every copy of an asset on the page in sync #}
+                                                                                <div class="btn-group">
+                                                                                    {% if thisasset.assets_endDate != null and thisasset.assets_endDate < searchResults.PROJECT['DATEEND'] %}
+                                                                                        <button title="Asset to be removed" class="btn btn-sm btn-success" disabled><i class="fa fa-shopping-basket"></i></button>
+                                                                                    {% elseif thisasset.flagsblocks.COUNT.BLOCK < 1 %}
+                                                                                        <button title="Remove from project" {% if (not thisasset.assignment) or searchResults.PROJECT.ID != thisasset.assignment[0].projects_id %}style="display:none;"{% endif %} class="btn btn-sm btn-warning removeFromBasketAssetButton" data-assetid="{{ thisasset['assets_id'] }}" data-assetTypeId="{{ thisasset.assetTypes_id }}" data-assetGroupId="{{ asset.assetGroups_id }}"><i class="fa fa-shopping-basket"></i></button>
+                                                                                        {% if thisasset.assignment and searchResults.PROJECT.ID != thisasset.assignment[0].projects_id %}
+                                                                                            <button title="Assigned to {{ thisasset.assignment[0]['projects_name'] }}" class="btn btn-sm btn-success" disabled><i class="fa fa-shopping-basket"></i></button>
+                                                                                        {% endif %}
+                                                                                        <button title="Add to project" {% if thisasset.assignment %} style="display:none;"{% endif %} class="btn btn-sm btn-success addToBasketAssetButton" data-assetid="{{ thisasset['assets_id'] }}" data-assetTypeId="{{ thisasset.assetTypes_id }}" data-assetGroupId="{{ asset.assetGroups_id }}"><i class="fa fa-shopping-basket"></i></button>
+                                                                                    {% else %}
+                                                                                        <button class="btn btn-sm btn-danger" title="Asset is blocked from being assigned by a maintenance job" disabled><i class="fas fa-ban"></i></button>
+                                                                                    {% endif %}
+                                                                                </div>
+                                                                            </td>
+                                                                            {% endif %}
+                                                                        </tr>
+                                                                    {% endfor %}
+                                                                </table>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <button type="button" class="btn btn-sm {{ searchResults.PROJECT.ID ? (asset.countAvailable > 0 ? 'btn-success' : 'btn-warning') : 'btn-default' }}" title="{{ searchResults.PROJECT.ID ? 'Book from this group' : 'View group contents' }}" data-toggle="modal" data-target="#assetGroupDetailsModal{{ asset.assetGroups_id }}"><i class="fa {{ searchResults.PROJECT.ID ? 'fa-shopping-basket' : 'fa-list' }}"></i></button>
+                                                <a href="{{ CONFIG.ROOTURL }}/instances/groups.php" class="btn btn-sm btn-default" target="_blank">
+                                                    <i class="fas fa-info-circle"></i>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        {% else %}
                         <div class="col-auto d-flex align-items-stretch" style="padding: 10px;">
                             <div class="card">
                                 <div class="card-body" style="max-width: 250px;">
@@ -422,6 +517,7 @@
                                 </div>
                             </div>
                         </div>
+                        {% endif %}
                     {% endfor %}
                 </div>
             </div>
@@ -495,14 +591,17 @@ $(document).ready(function () {
     // Uses defaultSelected/defaultChecked/defaultValue instead of the browser's
     // first-option pick.
     function resetAdvancedFields() {
+        var changed = false;
         $advancedSection.find('input, select, textarea').each(function () {
             var el = this;
             if (el.name && ADVANCED_EXEMPT_FROM_RESET[el.name]) return;
             if (el.type === 'checkbox' || el.type === 'radio') {
+                if (el.checked !== el.defaultChecked) changed = true;
                 el.checked = el.defaultChecked;
             } else if (el.tagName === 'SELECT') {
                 var anyDefault = false;
                 $(el).find('option').each(function () {
+                    if (this.selected !== this.defaultSelected) changed = true;
                     this.selected = this.defaultSelected;
                     if (this.defaultSelected) anyDefault = true;
                 });
@@ -515,13 +614,37 @@ $(document).ready(function () {
                 // top-level `change` handler (which would re-trigger a search).
                 $(el).trigger('change.select2');
             } else {
+                if (el.value !== el.defaultValue) changed = true;
                 el.value = el.defaultValue;
             }
         });
+        return changed;
     }
 
-    // Advanced always starts collapsed — deliberately do not persist state.
-    var advancedOpen = false;
+    // True when any advanced content filter is currently set (tags, manufacturer, group,
+    // category, dates, or the show-linked/archived checkboxes). Non-destructive - only reads.
+    // The action-context fields (project / project_referer) are ignored here. Every advanced
+    // select is a multi-select, so a selected option always reflects a real, explicit filter
+    // (no browser auto-selection to confuse us).
+    function advancedFiltersActive() {
+        var active = false;
+        $advancedSection.find('input, select, textarea').each(function () {
+            var el = this;
+            if (el.name && ADVANCED_EXEMPT_FROM_RESET[el.name]) return;
+            if (el.type === 'checkbox' || el.type === 'radio') {
+                if (el.checked) active = true;
+            } else if (el.tagName === 'SELECT') {
+                if ($(el).find('option:selected').length > 0) active = true;
+            } else if (el.value !== '' && el.value != null) {
+                active = true;
+            }
+        });
+        return active;
+    }
+
+    // Start the panel open when a filter arrived active from the URL, so it is never
+    // silently applied from behind a collapsed panel; otherwise start collapsed.
+    var advancedOpen = advancedFiltersActive();
     function applyAdvancedVisibility() {
         if (advancedOpen) {
             $advancedSection.show();
@@ -538,15 +661,18 @@ $(document).ready(function () {
             // Clear the advanced content filters when hiding them, so a filter left
             // set in a collapsed panel can never silently narrow the search. The
             // keyword box and scope bar sit outside the panel and stay put.
-            resetAdvancedFields();
+            return resetAdvancedFields();
         }
+        return false;
     }
     applyAdvancedVisibility();
     $advancedToggle.on('click', function (e) {
         e.preventDefault();
         advancedOpen = !advancedOpen;
-        applyAdvancedVisibility();
-        // Do not trigger a search — visibility toggle only.
+        var clearedActiveFilters = applyAdvancedVisibility();
+        // Collapsing clears the advanced filters; if that actually changed anything, refresh the
+        // results so they stop reflecting the now-cleared filters. Opening never searches.
+        if (!advancedOpen && clearedActiveFilters) scheduleSearch(0);
     });
 
     // --- Auto-search machinery ---------------------------------------------
@@ -567,7 +693,7 @@ $(document).ready(function () {
         'simple': 1, 'simple_keyword': 1, 'page': 1,
         'project': 1, 'project_referer': 1,
         'instance_id': 1, 'resultsperpage': 1, 'sort': 1,
-        'showlinked': 1, 'showarchived': 1, 'hideimages': 1,
+        'showlinked': 1, 'showarchived': 1, 'hideimages': 1, 'showgroups': 1,
         'tags[]': 1, 'manufacturer[]': 1, 'group[]': 1, 'category[]': 1, 'dates': 1,
     };
 
@@ -873,6 +999,27 @@ $(document).ready(function () {
                 var assetId = $(this).data("assetid");
                 if (failedIds.indexOf(assetId) === -1) {
                     $(this).hide();
+                    $(".removeFromBasketAssetButton[data-assetid=" + assetId + "]").show();
+                }
+            });
+            thisButton.prop('disabled', true);
+            Toast.fire({
+                type: 'success',
+                title: 'Added to ' + currentProjectName()
+            });
+        });
+    });
+    $(document).on('click', '#assetSearchResults .addToBasketGroupButton', function () {
+        const thisButton = $(this);
+        var groupId = thisButton.data("assetgroupid");
+        ajaxcall("projects/assets/assign.php", {"assetGroups_id":groupId,"projects_id":currentProjectId()}, function (data) {
+            var failedIds = (data.response && data.response.failed ? data.response.failed : []).map(function(f) { return f.assets_id; });
+            $(".addToBasketAssetButton[data-assetgroupid=" + groupId + "]").each(function() {
+                var assetId = $(this).data("assetid");
+                if (failedIds.indexOf(assetId) === -1) {
+                    // Sync every copy of this asset on the page (search cards, type modals and
+                    // other group cards), not just the button inside this group's modal.
+                    $(".addToBasketAssetButton[data-assetid=" + assetId + "]").hide();
                     $(".removeFromBasketAssetButton[data-assetid=" + assetId + "]").show();
                 }
             });


### PR DESCRIPTION
Closes #1013

> **Stacked on #1012.** This builds on the instant asset search (#1011 / PR #1012) and is branched off it. Until #1012 merges, GitHub shows both commits in this diff — **review only `Show Asset Groups as result cards in the asset search` here**, or review after #1012 lands, at which point this diff resolves to the groups change alone. Kept as a draft for that reason.

## Problem
Booking or reviewing a pre-defined kit set from the Asset Search page is awkward. Searching for an Asset Group returns the individual asset types, with no obvious way to add the whole group — and a type's "add" button books every asset of that type, not just the group's (#940). Working with the group as a group means leaving the search for the Groups page.

## What this changes
Asset Groups whose name, description or member assets match the search now appear as **their own result cards** alongside the asset types.

- Each card previews its members with costs.
- **With a project selected**, the whole group can be added in one click (dolly), or members picked out individually — scoped to *the group's* assets only, resolving the confusion in #940.
- **With no project selected**, the card is informational; the booking controls only render once a project is chosen.
- A **"Show asset groups"** scope toggle (on by default, beside "Hide asset images") turns the cards on/off, in both the quick keyword and advanced views.
- When the Advanced **Group** filter names specific groups, the cards are restricted to exactly those (keyword ignored for them); otherwise groups match on the search text.
- Groups always lead the page, whatever the sort — they have no price, mass, value or date to sort against the asset types.
- "Add the whole group" hides the add button on every copy of each member across the page (search cards, type modals, other group cards).
- Only rendered on page 1 and for the current instance (pagination counts assetTypes rows; the assign endpoint resolves groups in the current instance only). A per-page member budget caps member rendering; an over-budget group still offers "add the whole group".

## Implementation notes
- `src/assets.php` and `src/assets.twig` only; no schema change, no build step.
- Per-row enrichment shared by the type list and the group member list is factored into a `hydrateAssetRow()` helper so both stay in step.
- Instance scoping preserved throughout.

## How to test
1. With a project selected, search a term matching an Asset Group — a group card appears leading the results.
2. Add the whole group (dolly) — every member is booked and its add button flips to remove across the page; add/remove individual members from the card.
3. Toggle **Show asset groups** off — the cards disappear; on — they return (works in both quick and advanced views).
4. In Advanced, pick a specific Group — only that group's card shows, keyword ignored for it.
5. With no project selected, the card shows as an informational member/cost list with no booking controls.

## Known follow-up (out of scope)
A multi-asset *type* card's basket icon does not yet reflect what's booked into the project (per-asset sync does). That's deliberately left for a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
