### PR TITLE
[FEATURE] Location Dispatch: bulk-assign a location to a project's assets

### DIFF
--- a/src/api/projects/assets/setLocation.php
+++ b/src/api/projects/assets/setLocation.php
@@ -1,0 +1,213 @@
+<?php
+require_once __DIR__ . '/../../apiHeadSecure.php';
+
+if (
+    !$AUTH->instancePermissionCheck("PROJECTS:PROJECT_ASSETS:EDIT:ASSIGNMENT_STATUS")
+    || !isset($_POST['projects_id'])
+    || !isset($_POST['strategy'])
+    || !isset($_POST['assetsAssignments_id'])
+    || !is_array($_POST['assetsAssignments_id'])
+    || count($_POST['assetsAssignments_id']) === 0
+) finish(false, ["code" => "MISSINGFIELDS", "message" => "Missing required fields"]);
+
+$strategy = $_POST['strategy'];
+if (!in_array($strategy, ['project', 'storage', 'other'], true)) {
+    finish(false, ["code" => "INVALIDSTRATEGY", "message" => "Invalid strategy"]);
+}
+
+if ($strategy === 'other' && (!isset($_POST['locations_id']) || !is_numeric($_POST['locations_id']))) {
+    finish(false, ["code" => "MISSINGFIELDS", "message" => "locations_id required for 'other' strategy"]);
+}
+
+$projectsId = (int)$_POST['projects_id'];
+
+// Fetch project name for scan validation label (and venue for 'project' strategy)
+$DBLIB->where("projects_id", $projectsId);
+$DBLIB->where("instances_id", $AUTH->data['instance']['instances_id']);
+$DBLIB->where("projects_deleted", 0);
+$project = $DBLIB->getone("projects", ["projects_name", "locations_id"]);
+if (!$project) finish(false, ["code" => "NOTFOUND", "message" => "Project not found"]);
+$scanValidation = "Dispatched from Project " . $project['projects_name'];
+
+// Resolve project venue if needed
+$projectLocationId = null;
+if ($strategy === 'project') {
+    if (!$project['locations_id']) {
+        finish(false, ["code" => "NOVENUEASSIGNED", "message" => "This project has no venue assigned"]);
+    }
+    $projectLocationId = (int)$project['locations_id'];
+}
+
+// Validate 'other' location exists, is active, and belongs to an instance actually
+// represented here (the project's instance, or a sub-business whose asset is selected).
+// This prevents a caller injecting a locations_id from an unrelated tenant.
+if ($strategy === 'other') {
+    $allowedInstanceIds = [(int)$AUTH->data['instance']['instances_id']];
+    $DBLIB->where("assetsAssignments.assetsAssignments_id", array_map('intval', $_POST['assetsAssignments_id']), "IN");
+    $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
+    $DBLIB->where("projects.projects_id", $projectsId);
+    $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
+    $DBLIB->where("projects.projects_deleted", 0);
+    $DBLIB->where("assets.assets_deleted", 0);
+    $DBLIB->join("projects", "assetsAssignments.projects_id=projects.projects_id", "LEFT");
+    $DBLIB->join("assets", "assetsAssignments.assets_id=assets.assets_id", "LEFT");
+    $assignmentInstances = $DBLIB->get("assetsAssignments", null, ["assets.instances_id"]);
+    foreach ($assignmentInstances as $ai) {
+        if ($ai['instances_id'] !== null) $allowedInstanceIds[] = (int)$ai['instances_id'];
+    }
+    $allowedInstanceIds = array_values(array_unique($allowedInstanceIds));
+
+    $DBLIB->where("locations_id", (int)$_POST['locations_id']);
+    $DBLIB->where("instances_id", $allowedInstanceIds, "IN");
+    $DBLIB->where("locations_deleted", 0);
+    $DBLIB->where("locations_archived", 0);
+    $loc = $DBLIB->getone("locations", ["locations_id"]);
+    if (!$loc) finish(false, ["code" => "INVALIDLOCATION", "message" => "Location not found"]);
+}
+
+// Cache location barcodes to avoid repeated queries for the same location
+$locationBarcodeCache = [];
+function getLocationBarcodeId($locationsId) {
+    global $DBLIB, $locationBarcodeCache;
+    if (isset($locationBarcodeCache[$locationsId])) return $locationBarcodeCache[$locationsId];
+    $DBLIB->where("locations_id", $locationsId);
+    $DBLIB->where("locationsBarcodes_deleted", 0);
+    $DBLIB->orderBy("locationsBarcodes_id", "ASC");
+    $lb = $DBLIB->getone("locationsBarcodes", ["locationsBarcodes_id"]);
+    $id = ($lb ? (int)$lb['locationsBarcodes_id'] : null);
+    $locationBarcodeCache[$locationsId] = $id;
+    return $id;
+}
+
+$succeeded = [];
+$skipped = [];
+
+foreach ($_POST['assetsAssignments_id'] as $rawId) {
+    $assignmentId = (int)$rawId;
+
+    // Fetch assignment + asset, scoped to this project and instance
+    $DBLIB->where("assetsAssignments.assetsAssignments_id", $assignmentId);
+    $DBLIB->where("assetsAssignments.assetsAssignments_deleted", 0);
+    $DBLIB->where("projects.projects_id", $projectsId);
+    $DBLIB->where("projects.instances_id", $AUTH->data['instance']['instances_id']);
+    $DBLIB->where("projects.projects_deleted", 0);
+    $DBLIB->where("assets.assets_deleted", 0);
+    $DBLIB->join("projects", "assetsAssignments.projects_id=projects.projects_id", "LEFT");
+    $DBLIB->join("assets", "assetsAssignments.assets_id=assets.assets_id", "LEFT");
+    $assignment = $DBLIB->getone("assetsAssignments", [
+        "assetsAssignments.assetsAssignments_id",
+        "assetsAssignments.assets_id",
+        "assets.assets_tag",
+        "assets.assets_storageLocation",
+    ]);
+
+    if (!$assignment || !$assignment['assets_id']) {
+        $skipped[] = ["assetsAssignments_id" => $assignmentId, "assets_tag" => null, "reason" => "Asset not found"];
+        continue;
+    }
+
+    // Determine target location
+    $targetLocationId = null;
+    if ($strategy === 'project') {
+        $targetLocationId = $projectLocationId;
+    } elseif ($strategy === 'storage') {
+        if (!$assignment['assets_storageLocation']) {
+            $skipped[] = [
+                "assetsAssignments_id" => $assignmentId,
+                "assets_tag" => $assignment['assets_tag'],
+                "reason" => "No storage location set",
+            ];
+            continue;
+        }
+        $targetLocationId = (int)$assignment['assets_storageLocation'];
+    } elseif ($strategy === 'other') {
+        $targetLocationId = (int)$_POST['locations_id'];
+    }
+
+    // Find asset's primary barcode
+    $DBLIB->where("assets_id", (int)$assignment['assets_id']);
+    $DBLIB->where("assetsBarcodes_deleted", 0);
+    $DBLIB->orderBy("assetsBarcodes_id", "ASC");
+    $assetBarcode = $DBLIB->getone("assetsBarcodes", ["assetsBarcodes_id"]);
+
+    if (!$assetBarcode) {
+        $skipped[] = [
+            "assetsAssignments_id" => $assignmentId,
+            "assets_tag" => $assignment['assets_tag'],
+            "reason" => "No barcode registered for asset",
+        ];
+        continue;
+    }
+
+    // Find location barcode for the target location
+    $locationBarcodeId = getLocationBarcodeId($targetLocationId);
+    if (!$locationBarcodeId) {
+        $skipped[] = [
+            "assetsAssignments_id" => $assignmentId,
+            "assets_tag" => $assignment['assets_tag'],
+            "reason" => "Target location has no barcode",
+        ];
+        continue;
+    }
+
+    $DBLIB->insert("assetsBarcodesScans", [
+        "assetsBarcodes_id"                     => (int)$assetBarcode['assetsBarcodes_id'],
+        "users_userid"                          => $AUTH->data['users_userid'],
+        "assetsBarcodesScans_timestamp"         => date('Y-m-d H:i:s'),
+        "locationsBarcodes_id"                  => $locationBarcodeId,
+        //Not a physical barcode scan, so recorded the same way a manually set location is.
+        //assetsBarcodesScans_validation carries the provenance ("Dispatched from Project X").
+        "assetsBarcodesScans_barcodeWasScanned" => 0,
+        "assetsBarcodesScans_validation"        => $scanValidation,
+    ]);
+
+    $succeeded[] = ["assetsAssignments_id" => $assignmentId, "assets_tag" => $assignment['assets_tag']];
+}
+
+$bCMS->auditLog(
+    "LOCATION-DISPATCH",
+    "assetsAssignments",
+    "Strategy: " . $strategy . " | " . count($succeeded) . " succeeded, " . count($skipped) . " skipped",
+    $AUTH->data['users_userid'],
+    null,
+    $projectsId
+);
+
+finish(true, null, ["succeeded" => $succeeded, "skipped" => $skipped]);
+
+/** @OA\Post(
+ *     path="/projects/assets/setLocation.php",
+ *     summary="Location Dispatch: assign location to project assets",
+ *     description="Bulk-assigns a location to selected project asset assignments by creating barcode scan entries.
+Requires Instance Permission PROJECTS:PROJECT_ASSETS:EDIT:ASSIGNMENT_STATUS
+Strategies:
+- project: assigns the project's venue to all selected assets
+- storage: assigns each asset's own pre-defined storage location (assets without one are skipped)
+- other: assigns a caller-supplied locations_id to all selected assets
+Assets without a registered barcode are always skipped. Partial success is returned in the 'skipped' array.
+",
+ *     operationId="setAssetAssignmentLocation",
+ *     tags={"project_assets"},
+ *     @OA\Response(
+ *         response="200",
+ *         description="Success",
+ *         @OA\MediaType(
+ *             mediaType="application/json",
+ *             @OA\Schema(
+ *                 type="object",
+ *                 @OA\Property(property="result", type="boolean"),
+ *                 @OA\Property(
+ *                     property="response",
+ *                     type="object",
+ *                     @OA\Property(property="succeeded", type="array", @OA\Items(type="object")),
+ *                     @OA\Property(property="skipped",   type="array", @OA\Items(type="object")),
+ *                 ),
+ *             ),
+ *         ),
+ *     ),
+ *     @OA\Parameter(name="projects_id",           in="query", required=true,  @OA\Schema(type="number")),
+ *     @OA\Parameter(name="strategy",              in="query", required=true,  @OA\Schema(type="string", enum={"project","storage","other"})),
+ *     @OA\Parameter(name="assetsAssignments_id[]", in="query", required=true,  @OA\Schema(type="array", @OA\Items(type="number"))),
+ *     @OA\Parameter(name="locations_id",           in="query", required=false, @OA\Schema(type="number")),
+ * )
+ */

--- a/src/api/projects/data.php
+++ b/src/api/projects/data.php
@@ -132,6 +132,24 @@ function projectFinancials($project) {
 
         $asset['latestScan'] = assetLatestScan($asset['assets_id']);
 
+        //Storage location name, for the Location Dispatch asset table.
+        //Scoped to the asset's OWN instance (sub-business assets live in another
+        //instance), skipped when no storage location is set, and cached per
+        //(instances_id, locations_id) so the same location isn't re-queried per asset.
+        static $storageLocationCache = [];
+        $asset['storage_location'] = [];
+        if (!empty($asset['assets_storageLocation'])) {
+            $storageLocationCacheKey = $asset['instances_id'] . ':' . $asset['assets_storageLocation'];
+            if (!array_key_exists($storageLocationCacheKey, $storageLocationCache)) {
+                $DBLIB->where('locations_id', $asset['assets_storageLocation']);
+                $DBLIB->where('instances_id', $asset['instances_id']);
+                $DBLIB->where('locations_deleted', 0);
+                $DBLIB->where('locations_archived', 0);
+                $storageLocationCache[$storageLocationCacheKey] = $DBLIB->get('locations', 1, ['locations_id', 'locations_name']);
+            }
+            $asset['storage_location'] = $storageLocationCache[$storageLocationCacheKey];
+        }
+
         if ($asset['instances_id'] != $project['instances_id']) {
             if (!isset($return['assetsAssignedSUB'][$asset['instances_id']]['assets'])) $return['assetsAssignedSUB'][$asset['instances_id']]['assets'] = [];
             if (!isset($return['assetsAssignedSUB'][$asset['instances_id']]['assets'][$asset['assetTypes_id']])) $return['assetsAssignedSUB'][$asset['instances_id']]['assets'][$asset['assetTypes_id']]['assets'] = [];

--- a/src/project/index.php
+++ b/src/project/index.php
@@ -117,6 +117,24 @@ foreach ($PAGEDATA['FINANCIALS']['assetsAssignedSUB'] as $instance) { //Go throu
     }
 }
 
+// Locations for Location Dispatch modal "Other Location" dropdown (current instance)
+$DBLIB->where("instances_id", $AUTH->data['instance']['instances_id']);
+$DBLIB->where("locations_deleted", 0);
+$DBLIB->where("locations_archived", 0);
+$DBLIB->orderBy("locations_name", "ASC");
+$PAGEDATA['locationDispatchLocations'] = $DBLIB->get("locations", null, ["locations_id", "locations_name"]);
+
+// Locations for each sub-instance present in this project
+$PAGEDATA['locationDispatchSubLocations'] = [];
+foreach ($PAGEDATA['FINANCIALS']['assetsAssignedSUB'] as $subInstance) {
+    $subInstanceId = $subInstance['instance']['instances_id'];
+    $DBLIB->where("instances_id", $subInstanceId);
+    $DBLIB->where("locations_deleted", 0);
+    $DBLIB->where("locations_archived", 0);
+    $DBLIB->orderBy("locations_name", "ASC");
+    $PAGEDATA['locationDispatchSubLocations'][$subInstanceId] = $DBLIB->get("locations", null, ["locations_id", "locations_name"]);
+}
+
 //Edit Options - Project Statuses list
 if ($AUTH->instancePermissionCheck("PROJECTS:EDIT:STATUS")) {
     $DBLIB->where("instances_id", $AUTH->data['instance']['instances_id']);

--- a/src/project/project_assetsBoard.twig
+++ b/src/project/project_assetsBoard.twig
@@ -30,6 +30,12 @@
     #navItemBarcodeDispatch button {
         background-color: transparent;
     }
+    #navItemLocationDispatch {
+        height: 100%;
+    }
+    #navItemLocationDispatch button {
+        background-color: transparent;
+    }
 </style>
 <div class="card card-primary card-outline card-outline-tabs">
     <div class="card-header p-0 border-bottom-0 card-tabs">
@@ -53,6 +59,11 @@
                 <li class="nav-item" id="navItemBarcodeDispatch">
                     <button type="button" class="nav-link" title="Barcode Dispatch" data-toggle="modal" data-target="#barcodeDispatchModal">
                         <i class="fas fa-barcode"></i>
+                    </button>
+                </li>
+                <li class="nav-item" id="navItemLocationDispatch">
+                    <button type="button" class="nav-link" title="Location Dispatch" data-toggle="modal" data-target="#locationDispatchModal">
+                        <i class="fas fa-map-marked-alt"></i>
                     </button>
                 </li>
             {% endif %}
@@ -195,6 +206,181 @@
                     {% endembed %}
                     <div id="barcodeDispatchResult"></div>
                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="modal fade" id="locationDispatchModal">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title"><i class="fas fa-map-marked-alt mr-2"></i>Location Dispatch</h4>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <ul class="nav nav-tabs" role="tablist">
+                    {% if FINANCIALS.assetsAssigned|length > 0 %}
+                        <li class="nav-item">
+                            <a class="nav-link active location-dispatch-tab" data-toggle="pill" href="#location-dispatch-tab-thisinstance" role="tab" data-instanceid="{{ USERDATA.instance.instances_id }}">{{ USERDATA.instance.instances_name }}</a>
+                        </li>
+                    {% endif %}
+                    {% for instance in FINANCIALS.assetsAssignedSUB %}
+                        <li class="nav-item">
+                            <a class="nav-link{% if FINANCIALS.assetsAssigned|length == 0 and loop.first %} active{% endif %} location-dispatch-tab" data-toggle="pill" href="#location-dispatch-tab-{{ instance.instance.instances_id }}" role="tab" data-instanceid="{{ instance.instance.instances_id }}">{{ instance.instance.instances_name }}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
+                <div class="tab-content pt-3">
+                    {% if FINANCIALS.assetsAssigned|length > 0 %}
+                    <div class="tab-pane show active" id="location-dispatch-tab-thisinstance" role="tabpanel">
+                        <div class="form-group">
+                            <label>Filter by Status</label>
+                            <select class="form-control locationDispatchStatusFilter">
+                                <option value="">All Statuses</option>
+                                {% for status in BOARDSTATUSES[USERDATA.instance.instances_id] %}
+                                    <option value="{{ status.assetsAssignmentsStatus_id }}">{{ status.assetsAssignmentsStatus_name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="table-responsive" style="max-height: 300px; overflow-y: auto;">
+                            <table class="table table-sm table-bordered mb-0">
+                                <thead class="thead-light">
+                                    <tr>
+                                        <th style="width: 30px;"><input type="checkbox" class="locationDispatchSelectAll" title="Select all visible"></th>
+                                        <th>Tag</th>
+                                        <th>Asset</th>
+                                        <th>Status</th>
+                                        <th>Current Location</th>
+                                        <th>Storage Location</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for status in BOARDASSETS[USERDATA.instance.instances_id] %}
+                                        {% for asset in status.assets %}
+                                            <tr class="location-dispatch-asset-row" data-statusid="{{ status.assetsAssignmentsStatus_id }}" data-instance="{{ USERDATA.instance.instances_id }}">
+                                                <td><input type="checkbox" class="location-dispatch-asset-checkbox" data-assignment="{{ asset.assetsAssignments_id }}" data-tag="{{ asset.assets_tag }}"></td>
+                                                <td><a href="{{ CONFIG.ROOTURL }}/asset.php?id={{ asset.assetTypes_id }}&asset={{ asset.assets_id }}&instance={{ USERDATA.instance.instances_id }}" target="_blank">{{ asset.assets_tag }}</a></td>
+                                                <td>{{ asset.assetTypes_name }}</td>
+                                                <td class="location-dispatch-status-cell">{{ status.assetsAssignmentsStatus_name }}</td>
+                                                <td>
+                                                    {% if asset.latestScan %}
+                                                        {% if asset.latestScan.locations_name %}{{ asset.latestScan.locations_name }}
+                                                        {% elseif asset.latestScan.assetTypes_name %}Inside {{ asset.latestScan.assetTypes_name }} ({{ asset.latestScan.assets_tag }})
+                                                        {% elseif asset.latestScan.assetsBarcodes_customLocation %}{{ asset.latestScan.assetsBarcodes_customLocation }}
+                                                        {% else %}<em class="text-muted">Unknown</em>{% endif %}
+                                                    {% else %}<em class="text-muted">No scan recorded</em>{% endif %}
+                                                </td>
+                                                <td>
+                                                    {% if asset.storage_location and asset.storage_location[0] is defined %}{{ asset.storage_location[0].locations_name }}
+                                                    {% else %}<em class="text-muted">None</em>{% endif %}
+                                                </td>
+                                            </tr>
+                                        {% endfor %}
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    {% endif %}
+                    {% for instance in FINANCIALS.assetsAssignedSUB %}
+                    <div class="tab-pane{% if FINANCIALS.assetsAssigned|length == 0 and loop.first %} show active{% endif %}" id="location-dispatch-tab-{{ instance.instance.instances_id }}" role="tabpanel">
+                        <div class="form-group">
+                            <label>Filter by Status</label>
+                            <select class="form-control locationDispatchStatusFilter">
+                                <option value="">All Statuses</option>
+                                {% for status in BOARDSTATUSES[instance.instance.instances_id] %}
+                                    <option value="{{ status.assetsAssignmentsStatus_id }}">{{ status.assetsAssignmentsStatus_name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="table-responsive" style="max-height: 300px; overflow-y: auto;">
+                            <table class="table table-sm table-bordered mb-0">
+                                <thead class="thead-light">
+                                    <tr>
+                                        <th style="width: 30px;"><input type="checkbox" class="locationDispatchSelectAll" title="Select all visible"></th>
+                                        <th>Tag</th>
+                                        <th>Asset</th>
+                                        <th>Status</th>
+                                        <th>Current Location</th>
+                                        <th>Storage Location</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for status in BOARDASSETS[instance.instance.instances_id] %}
+                                        {% for asset in status.assets %}
+                                            <tr class="location-dispatch-asset-row" data-statusid="{{ status.assetsAssignmentsStatus_id }}" data-instance="{{ instance.instance.instances_id }}">
+                                                <td><input type="checkbox" class="location-dispatch-asset-checkbox" data-assignment="{{ asset.assetsAssignments_id }}" data-tag="{{ asset.assets_tag }}"></td>
+                                                <td><a href="{{ CONFIG.ROOTURL }}/asset.php?id={{ asset.assetTypes_id }}&asset={{ asset.assets_id }}&instance={{ instance.instance.instances_id }}" target="_blank">{{ asset.assets_tag }}</a></td>
+                                                <td>{{ asset.assetTypes_name }}</td>
+                                                <td class="location-dispatch-status-cell">{{ status.assetsAssignmentsStatus_name }}</td>
+                                                <td>
+                                                    {% if asset.latestScan %}
+                                                        {% if asset.latestScan.locations_name %}{{ asset.latestScan.locations_name }}
+                                                        {% elseif asset.latestScan.assetTypes_name %}Inside {{ asset.latestScan.assetTypes_name }} ({{ asset.latestScan.assets_tag }})
+                                                        {% elseif asset.latestScan.assetsBarcodes_customLocation %}{{ asset.latestScan.assetsBarcodes_customLocation }}
+                                                        {% else %}<em class="text-muted">Unknown</em>{% endif %}
+                                                    {% else %}<em class="text-muted">No scan recorded</em>{% endif %}
+                                                </td>
+                                                <td>
+                                                    {% if asset.storage_location and asset.storage_location[0] is defined %}{{ asset.storage_location[0].locations_name }}
+                                                    {% else %}<em class="text-muted">None</em>{% endif %}
+                                                </td>
+                                            </tr>
+                                        {% endfor %}
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+                <div class="mt-1 mb-3">
+                    <small class="text-muted" id="locationDispatchSelectionCount">0 assets selected</small>
+                </div>
+                <hr>
+                <div class="form-group">
+                    <label>Target Location Strategy</label>
+                    <div>
+                        <div class="form-check mb-1" id="locationStrategyProjectGroup">
+                            <input class="form-check-input" type="radio" name="locationStrategy" id="locationStrategyProject" value="project"
+                                {{ project.locations_id ? '' : 'disabled' }}>
+                            <label class="form-check-label" for="locationStrategyProject">
+                                Project Location
+                                {% if project.locations_id %}
+                                    — <strong>{{ project.locations_name }}</strong>
+                                {% else %}
+                                    <span class="text-muted">(disabled — no venue assigned to this project)</span>
+                                {% endif %}
+                            </label>
+                        </div>
+                        <div class="form-check mb-1">
+                            <input class="form-check-input" type="radio" name="locationStrategy" id="locationStrategyStorage" value="storage" checked>
+                            <label class="form-check-label" for="locationStrategyStorage">
+                                Asset Storage Location <span class="text-muted">(each asset's own home location; assets with none set will be skipped)</span>
+                            </label>
+                        </div>
+                        <div class="form-check mb-2">
+                            <input class="form-check-input" type="radio" name="locationStrategy" id="locationStrategyOther" value="other">
+                            <label class="form-check-label" for="locationStrategyOther">
+                                Other Location
+                            </label>
+                        </div>
+                        <div id="locationDispatchOtherLocationGroup" style="display: none;" class="ml-4">
+                            <select class="form-control" id="locationDispatchOtherLocation">
+                                <option value="">Select a location…</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+                <div id="locationDispatchResult"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="locationDispatchConfirm">
+                    <i class="fas fa-map-marked-alt mr-1"></i>Assign Location
+                </button>
             </div>
         </div>
     </div>
@@ -478,6 +664,191 @@
             doQuickDispatch();
         });
         $("#goQuickDispatch").on("click", doQuickDispatch);
+
+        // ── Location Dispatch ─────────────────────────────────────────────────
+
+        // The active tab pane — the count and the dispatch action are scoped to it so
+        // selections on hidden sub-business tabs never leak into the visible tab.
+        function locationDispatchActivePane() {
+            return $("#locationDispatchModal .tab-pane.active");
+        }
+
+        function locationDispatchUpdateCount() {
+            var count = locationDispatchActivePane().find(".location-dispatch-asset-checkbox:checked").length;
+            $("#locationDispatchSelectionCount").text(count + " asset" + (count === 1 ? "" : "s") + " selected");
+        }
+
+        // Status filter — scoped to the tab pane it lives in
+        $(document).on("change", ".locationDispatchStatusFilter", function () {
+            var tabPane = $(this).closest(".tab-pane");
+            var statusId = $(this).val();
+            tabPane.find(".location-dispatch-asset-row").show();
+            if (statusId !== "") {
+                tabPane.find(".location-dispatch-asset-row").hide();
+                tabPane.find(".location-dispatch-asset-row[data-statusid='" + statusId + "']").show();
+            }
+            tabPane.find(".locationDispatchSelectAll").prop("checked", false);
+            locationDispatchUpdateCount();
+        });
+
+        // Select all — scoped to visible rows in the tab pane it lives in
+        $(document).on("change", ".locationDispatchSelectAll", function () {
+            var tabPane = $(this).closest(".tab-pane");
+            var checked = $(this).prop("checked");
+            tabPane.find(".location-dispatch-asset-row:visible .location-dispatch-asset-checkbox").prop("checked", checked);
+            locationDispatchUpdateCount();
+        });
+
+        $(document).on("change", ".location-dispatch-asset-checkbox", function () {
+            locationDispatchUpdateCount();
+        });
+
+        $('input[name="locationStrategy"]').on("change", function () {
+            $("#locationDispatchOtherLocationGroup").toggle($(this).val() === "other");
+        });
+
+        // Locations per instance for the "Other Location" dropdown
+        var locationDispatchAllLocations = {};
+        locationDispatchAllLocations["{{ USERDATA.instance.instances_id }}"] = {{ locationDispatchLocations|json_encode|raw }};
+        {% for instance in FINANCIALS.assetsAssignedSUB %}
+        locationDispatchAllLocations["{{ instance.instance.instances_id }}"] = {{ locationDispatchSubLocations[instance.instance.instances_id]|json_encode|raw }};
+        {% endfor %}
+        var locationDispatchMainInstanceId = "{{ USERDATA.instance.instances_id }}";
+
+        function locationDispatchUpdateForInstance(instanceId) {
+            var isMainInstance = (String(instanceId) === String(locationDispatchMainInstanceId));
+            // "Project Location" only makes sense for the current instance's assets
+            $("#locationStrategyProjectGroup").toggle(isMainInstance);
+            if (!isMainInstance && $('input[name="locationStrategy"]:checked').val() === "project") {
+                $('input[name="locationStrategy"][value="storage"]').prop("checked", true);
+                $("#locationDispatchOtherLocationGroup").hide();
+            }
+            // Repopulate "Other Location" dropdown with this instance's locations
+            var locations = locationDispatchAllLocations[instanceId] || [];
+            var select = $("#locationDispatchOtherLocation").empty().append('<option value="">Select a location…</option>');
+            locations.forEach(function (loc) {
+                select.append($("<option>").val(loc.locations_id).text(loc.locations_name));
+            });
+        }
+
+        // Update strategy options when the user switches tabs inside the modal
+        $("#locationDispatchModal").on("shown.bs.tab", ".location-dispatch-tab", function () {
+            locationDispatchUpdateForInstance($(this).data("instanceid"));
+            // Recount for the newly visible tab
+            locationDispatchUpdateCount();
+        });
+
+        // Sync status labels and data-statusid from the live board DOM on open
+        $("#locationDispatchModal").on("show.bs.modal", function () {
+            $(".location-dispatch-asset-row").each(function () {
+                var row = $(this);
+                var assignmentId = row.find(".location-dispatch-asset-checkbox").data("assignment");
+                var instanceId = row.data("instance");
+                var card = $(".assetDispatchAssetList-card[data-assignment='" + assignmentId + "']");
+                if (!card.length) return;
+                var currentStatusId = card.closest(".assetDispatchAssetList").data("statusid");
+                row.attr("data-statusid", currentStatusId);
+                var allStatuses = assetStatuses[instanceId] ? assetStatuses[instanceId].allData : [];
+                var statusName = "";
+                if (Array.isArray(allStatuses)) {
+                    var s = allStatuses.find(function (s) { return s.assetsAssignmentsStatus_id == currentStatusId; });
+                    statusName = s ? s.assetsAssignmentsStatus_name : "";
+                } else {
+                    for (var key in allStatuses) {
+                        if (allStatuses[key].assetsAssignmentsStatus_id == currentStatusId) { statusName = allStatuses[key].assetsAssignmentsStatus_name; break; }
+                    }
+                }
+                row.find(".location-dispatch-status-cell").text(statusName);
+            });
+            // Set strategy options for whichever tab is active when the modal opens
+            var activeTab = $("#locationDispatchModal").find(".location-dispatch-tab.active");
+            locationDispatchUpdateForInstance(activeTab.length ? activeTab.data("instanceid") : locationDispatchMainInstanceId);
+        });
+
+        $("#locationDispatchModal").on("hidden.bs.modal", function () {
+            $(".locationDispatchStatusFilter").each(function () {
+                $(this).val("");
+                $(this).closest(".tab-pane").find(".location-dispatch-asset-row").show();
+            });
+            $(".locationDispatchSelectAll").prop("checked", false);
+            $(".location-dispatch-asset-checkbox").prop("checked", false);
+            $('input[name="locationStrategy"][value="storage"]').prop("checked", true);
+            $("#locationDispatchOtherLocationGroup").hide();
+            $("#locationDispatchResult").empty();
+            locationDispatchUpdateCount();
+        });
+
+        $("#locationDispatchConfirm").on("click", function () {
+            var strategy = $('input[name="locationStrategy"]:checked').val();
+            if (!strategy) {
+                Toast.fire({ type: "warning", title: "Please select a location strategy" });
+                return;
+            }
+            if (strategy === "other" && !$("#locationDispatchOtherLocation").val()) {
+                Toast.fire({ type: "warning", title: "Please select a target location" });
+                return;
+            }
+
+            var selectedIds = [];
+            locationDispatchActivePane().find(".location-dispatch-asset-checkbox:checked").each(function () {
+                selectedIds.push($(this).data("assignment"));
+            });
+            if (selectedIds.length === 0) {
+                Toast.fire({ type: "warning", title: "No assets selected" });
+                return;
+            }
+
+            var postData = {
+                projects_id: {{ project.projects_id }},
+                strategy: strategy,
+                "assetsAssignments_id[]": selectedIds
+            };
+            if (strategy === "other") {
+                postData.locations_id = $("#locationDispatchOtherLocation").val();
+            }
+
+            $("#locationDispatchConfirm").prop("disabled", true).html('<i class="fas fa-spinner fa-spin mr-1"></i>Assigning…');
+            $("#locationDispatchResult").empty();
+
+            $.ajax({
+                url: "{{ CONFIG.ROOTURL }}/api/projects/assets/setLocation.php",
+                type: "POST",
+                data: postData,
+                cache: false,
+                success: function (result) {
+                    $("#locationDispatchConfirm").prop("disabled", false).html('<i class="fas fa-map-marked-alt mr-1"></i>Assign Location');
+                    if (!result.result) {
+                        var msg = (result.error && result.error.message) ? result.error.message : "An error occurred";
+                        Toast.fire({ type: "error", title: msg });
+                        return;
+                    }
+                    var succeeded = result.response.succeeded;
+                    var skipped   = result.response.skipped;
+
+                    if (skipped.length === 0) {
+                        Toast.fire({ type: "success", title: succeeded.length + " asset" + (succeeded.length === 1 ? "" : "s") + " assigned to location" });
+                        $("#locationDispatchModal").modal("hide");
+                    } else {
+                        var summary = $("<div>").addClass("alert alert-warning mt-2");
+                        summary.append($("<strong>").text(succeeded.length + " assigned, " + skipped.length + " skipped:"));
+                        var list = $("<ul class='mb-0 mt-1'>");
+                        skipped.forEach(function (item) {
+                            list.append($("<li>").text((item.assets_tag || "Unknown") + ": " + item.reason));
+                        });
+                        summary.append(list);
+                        $("#locationDispatchResult").html(summary);
+                        if (succeeded.length > 0) {
+                            Toast.fire({ type: "warning", title: succeeded.length + " assigned, " + skipped.length + " skipped — see modal for details" });
+                        }
+                    }
+                },
+                error: function () {
+                    $("#locationDispatchConfirm").prop("disabled", false).html('<i class="fas fa-map-marked-alt mr-1"></i>Assign Location');
+                    bootbox.alert("Sorry, we couldn't connect to the server — please check your connection");
+                }
+            });
+        });
+
         {% endif %}
 
 


### PR DESCRIPTION
Closes #1015

## Problem
Checking a truckload of kit in or out means scanning every barcode individually, even when every asset is going to the same place. There is no way to set the current location on many of a project's assets at once.

## What this changes
A **Location Dispatch** action on **Project > Asset Dispatch**, alongside Quick Dispatch and Barcode Dispatch. It lists the project's assets (tabbed per sub-business, filterable by assignment status, with select-all) and bulk-sets a location on the selected ones using one of three strategies:

- **Project Location** — the project's assigned venue (disabled when no venue is set).
- **Asset Storage Location** — each asset's own storage location.
- **Other Location** — one chosen location applied to all selected assets.

Assets that cannot be placed are **skipped, not failed** — the batch processes the rest and reports each skip with a reason (no storage location set, or the target location has no barcode to scan against). The dialog's asset table shows each asset's current and storage location up front, so it is clear which assets the Asset Storage Location strategy covers.

Each move is recorded as an `assetsBarcodesScans` row, tagged in `assetsBarcodesScans_validation` as "Dispatched from Project X" — which the asset history and the project asset-list badge already render.

## Implementation notes
- `src/api/projects/assets/setLocation.php` (new) — validates the strategy, resolves the target location per asset, scans, returns `{succeeded, skipped}`.
- `src/project/project_assetsBoard.twig` — the dialog and its JS.
- `src/project/index.php` — passes the data the dialog needs.
- `src/api/projects/data.php` — `projectFinancials()` gains a lookup resolving each asset's storage-location name for the table.
- No schema change.

## Open question for the maintainer
The scan is written with `assetsBarcodesScans_barcodeWasScanned = 0` (the existing value for a location set without a physical scan) rather than a new value on that column. If you would prefer a distinct value so bulk dispatches are separable in reporting, that is a small migration — happy to switch.

## How to test
1. Project > Asset Dispatch > **Location Dispatch**.
2. **Project Location** — with a venue set, all selected assets move to it; with no venue, it reports `This project has no venue assigned` and changes nothing.
3. **Asset Storage Location** — assets with a storage location move there; those without are skipped and reported; the rest still succeed.
4. **Other Location** — pick a location, all selected move there; leaving it empty is blocked.
5. After each run, the result reports succeeded/skipped counts, and each affected asset's history shows "Dispatched from Project …".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
