### PR TITLE
[FEATURE] Expire logins on inactivity instead of a fixed 24-minute logout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,12 @@ COPY ./phinx.php /var/www/html
 COPY ./migrate.sh /var/www/html
 RUN chmod +x /var/www/html/migrate.sh
 
+# Session storage. This sits outside the document root so it can be mounted as a volume and
+# survive container restarts, and is owned by www-data so a new named volume inherits that.
+RUN mkdir -p /var/lib/adamrms-sessions \
+    && chown www-data:www-data /var/lib/adamrms-sessions \
+    && chmod 700 /var/lib/adamrms-sessions
+
 # Switch to the base image non-privileged user that the app will run under.
 USER www-data
 

--- a/db/migrations/20260901120000_auth_token_last_used.php
+++ b/db/migrations/20260901120000_auth_token_last_used.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AuthTokenLastUsed extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Adds the timestamp that drives sliding session expiry. Logins used to expire a fixed
+     * 12 hours after they were created; they now expire after a configurable period of
+     * inactivity instead, measured from this column.
+     */
+    public function change(): void
+    {
+        $this->table('authTokens')
+            ->addColumn('authTokens_lastUsed', 'timestamp', [
+                'null' => true,
+                'default' => null,
+                'comment' => 'Last time this token authenticated a request - drives sliding session expiry. authTokens_created stays the login time.',
+                'after' => 'authTokens_created'
+            ])
+            ->save();
+
+        //Judge existing logins from when they were created, rather than treating them as never used
+        $this->execute('UPDATE authTokens SET authTokens_lastUsed = authTokens_created WHERE authTokens_lastUsed IS NULL');
+    }
+}

--- a/src/common/head.php
+++ b/src/common/head.php
@@ -183,10 +183,47 @@ $PAGEDATA['MAINTENANCEJOBPRIORITIES'] = $GLOBALS['MAINTENANCEJOBPRIORITIES'];
 // Include Twig Extensions
 require_once __DIR__ . '/libs/twigExtensions.php';
 
+// Did this request actually arrive over https? The reverse proxy terminates TLS, so $_SERVER['HTTPS'] alone isn't enough
+function requestIsHttps() {
+    if (!empty($_SERVER['HTTPS']) and strtolower($_SERVER['HTTPS']) !== 'off') return true;
+    if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) and strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https') return true;
+    return false;
+}
+
+// How long a login lasts (in seconds) before inactivity ends it - configurable server-wide
+function authSessionLifetimeSeconds() {
+    global $CONFIG;
+    $days = intval($CONFIG['AUTH_SESSION_LIFETIME_DAYS'] ?? 7);
+    if ($days < 1 or $days > 365) $days = 7; //Guard against a missing or nonsense config value
+    return $days * 24 * 60 * 60;
+}
+
 // Try to open up a session cookie
 try {
-    session_set_cookie_params(43200); //12hours
+    $sessionLifetime = authSessionLifetimeSeconds();
+    //Without this PHP bins the session data after 24 minutes idle, no matter how long the cookie lasts
+    ini_set('session.gc_maxlifetime', $sessionLifetime);
+    ini_set('session.use_strict_mode', '1'); //Don't adopt a session id the client made up
+    //A dedicated directory stops another PHP process sweeping /tmp with the default lifetime from binning our sessions,
+    //and lets the container mount it as a volume so logins survive a restart
+    $sessionSavePath = getenv('SESSION_SAVE_PATH') ?: '/var/lib/adamrms-sessions';
+    if (!is_dir($sessionSavePath)) @mkdir($sessionSavePath, 0700, true);
+    //If we can't write there, stay on PHP's default - a session that can't be saved logs everybody out silently
+    if (is_dir($sessionSavePath) and is_writable($sessionSavePath)) session_save_path($sessionSavePath);
+    $sessionCookieParams = [
+        'path' => '/',
+        'domain' => '',
+        //Only mark it secure when the request really came over https, or direct http access could never log in
+        'secure' => requestIsHttps(),
+        'httponly' => true,
+        'samesite' => 'Lax',
+    ];
+    session_set_cookie_params(['lifetime' => $sessionLifetime] + $sessionCookieParams);
     session_start(); //Open up the session
+    //PHP only sends the cookie when the session is created, so re-send it to slide the expiry forward on every request
+    if (session_status() === PHP_SESSION_ACTIVE and isset($_COOKIE[session_name()]) and !headers_sent()) {
+        setcookie(session_name(), session_id(), ['expires' => time() + $sessionLifetime] + $sessionCookieParams);
+    }
 } catch (Exception $e) {
     //Do Nothing
 }

--- a/src/common/headSecure.php
+++ b/src/common/headSecure.php
@@ -5,7 +5,8 @@ require_once __DIR__ . '/../assets/widgets/statsWidgets.php'; //Stats on homepag
 //THIS IS DUPLICATED SOMEWHAT IN API HEAD SECURE AS SECURITY IS HANDLED SLIGHTLY DIFFERENTLY ON THE API END
 
 if (!$GLOBALS['AUTH']->login) {
-    $_SESSION['return'] = str_replace("src/", "", "http://" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+    //Must match the scheme the request came in on - sending an https user back to http drops the secure session cookie
+    $_SESSION['return'] = str_replace("src/", "", (requestIsHttps() ? "https://" : "http://") . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
     if ($CONFIG['DEV']) die($GLOBALS['AUTH']->debug . "<br/><a href='" . $CONFIG['ROOTURL'] . "/login/'>" . $CONFIG['ROOTURL'] . "/login/</a>");
     header("Location: " . $CONFIG['ROOTURL'] . "/login/");
     die('<meta http-equiv="refresh" content="0; url="' . $CONFIG['ROOTURL'] . "/login/" . '" />');

--- a/src/common/libs/Auth/main.php
+++ b/src/common/libs/Auth/main.php
@@ -17,6 +17,7 @@ class AuthFail extends Exception {
 class bID
 {
     const TOKEN_LENGTH = 32;
+    const TOKEN_LASTUSED_REFRESH = 300; //Only bump a token's last used timestamp every 5 minutes, to keep writes down
     public $VALIDMAGICLINKREDIRECTS = ["com.bstudios.adamrms://magic-link"];
     public $login;
     private $token;
@@ -42,6 +43,39 @@ class bID
         } elseif (isset($_SESSION['token'])) return ["token" => $_SESSION['token'], "type" => "web-session"];
         else throw new AuthFail('No token found');
     }
+    private function clientIpFromForwardedFor($header) {
+        //The client is the first entry in an X-Forwarded-For chain
+        $forwardedFor = explode(",", $header);
+        return trim(array_shift($forwardedFor));
+    }
+    private function tokenLifetimeSeconds($tokenType) {
+        //Magic links are emailed, so they stay short lived however long normal sessions are configured to last
+        if ($tokenType == "app-v2-magic-email") return 12 * 60 * 60;
+        return authSessionLifetimeSeconds();
+    }
+    private function checkTokenIpAddress($tokenCheck) {
+        if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
+            if ($_SERVER["HTTP_CF_CONNECTING_IP"] != $tokenCheck["authTokens_ipAddress"]) {
+                throw new AuthFail("IP from Cloudflare doesn't match token. Received [" . $_SERVER["HTTP_CF_CONNECTING_IP"] . "] but expecting [" . $tokenCheck["authTokens_ipAddress"] . "]");
+            }
+        } elseif (isset($_SERVER["HTTP_X_FORWARDED_FOR"])) {
+            $forwardedIp = $this->clientIpFromForwardedFor($_SERVER["HTTP_X_FORWARDED_FOR"]);
+            if ($forwardedIp != $tokenCheck["authTokens_ipAddress"]) {
+                throw new AuthFail("IP from Heroku/generic proxy doesn't match token. Received [" . $forwardedIp . "] but expecting [" . $tokenCheck["authTokens_ipAddress"] . "]");
+            }
+        } elseif ($_SERVER["REMOTE_ADDR"] != $tokenCheck["authTokens_ipAddress"]) {
+            throw new AuthFail("IP direct doesn't match token. Received [" . $_SERVER["REMOTE_ADDR"] . "] but expecting [" . $tokenCheck["authTokens_ipAddress"] . "]");
+        }
+    }
+    private function refreshTokenLastUsed($tokenCheck) {
+        global $DBLIB;
+        //Magic link tokens expire a fixed time after being emailed, so they never get their clock reset
+        if ($tokenCheck["authTokens_type"] == "app-v2-magic-email") return;
+        //Only write when the stored value has gone stale, so we don't add a database write to every single request
+        if ($tokenCheck["authTokens_lastUsed"] !== null and (strtotime($tokenCheck["authTokens_lastUsed"]) + self::TOKEN_LASTUSED_REFRESH) > time()) return;
+        $DBLIB->where("authTokens_id", $tokenCheck["authTokens_id"]);
+        $DBLIB->update("authTokens", ["authTokens_lastUsed" => date('Y-m-d H:i:s')]);
+    }
     private function checkToken($tokenPayload) {
         global $DBLIB, $CONFIG;
         $token = $tokenPayload['token'];
@@ -52,24 +86,22 @@ class bID
         $DBLIB->where('authTokens_token', $GLOBALS['bCMS']->sanitizeString($token));
         $DBLIB->where("authTokens_valid", '1');
         $DBLIB->where("authTokens_type", $tokenType);
-        $tokenCheck = $DBLIB->getOne("authTokens", ["authTokens_token", "authTokens_created", "authTokens_ipAddress", "users_userid", "authTokens_adminId", "authTokens_type", "authTokens_id"]);
+        $tokenCheck = $DBLIB->getOne("authTokens", ["authTokens_token", "authTokens_created", "authTokens_lastUsed", "authTokens_ipAddress", "users_userid", "authTokens_adminId", "authTokens_type", "authTokens_id"]);
 
-        if (!$tokenCheck) {
-            throw new AuthFail('Token not found in DB');
-        } elseif ((strtotime($tokenCheck["authTokens_created"]) + (12 * 60 * 60)) < time()) {
-             // Tokens are valid for 12 hrs (this includes the mobile app), which matches the session timeout
-            throw new AuthFail("Token expired at " . $tokenCheck["authTokens_created"] . " - server time is " . time());
-        } elseif (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
-            if ($_SERVER["HTTP_CF_CONNECTING_IP"] != $tokenCheck["authTokens_ipAddress"]) {
-                throw new AuthFail("IP from Cloudflare doesn't match token. Received [" . $_SERVER["HTTP_CF_CONNECTING_IP"] . "] but expecting [" . $tokenCheck["authTokens_ipAddress"] . "]");
-            }
-        } elseif(isset($_SERVER["HTTP_X_FORWARDED_FOR"])) {
-            if (array_shift(explode(",", $_SERVER["HTTP_X_FORWARDED_FOR"])) != $tokenCheck["authTokens_ipAddress"]) {
-                throw new AuthFail("IP from Heroku/generic proxy doesn't match token. Received [" . array_shift(explode(",", $_SERVER["HTTP_X_FORWARDED_FOR"])) . "] but expecting [" . $tokenCheck["authTokens_ipAddress"] . "]");
-            }
-        } elseif($_SERVER["REMOTE_ADDR"] != $tokenCheck["authTokens_ipAddress"]) {
-            throw new AuthFail("IP direct doesn't match token. Received [" . $_SERVER["REMOTE_ADDR"] . "] but expecting [" . $tokenCheck["authTokens_ipAddress"] . "]");
+        if (!$tokenCheck) throw new AuthFail('Token not found in DB');
+
+        // Tokens expire on inactivity rather than age, so someone using the site is never cut off mid-task.
+        // The window is set server wide by the AUTH_SESSION_LIFETIME_DAYS config value.
+        $lastActive = $tokenCheck["authTokens_lastUsed"] ?: $tokenCheck["authTokens_created"];
+        if ((strtotime($lastActive) + $this->tokenLifetimeSeconds($tokenType)) < time()) {
+            throw new AuthFail("Token expired - last used " . $lastActive . " - server time is " . time());
         }
+
+        // Tying a token to one IP address logs out anyone whose address changes (mobile data, VPN, ISP reconnect),
+        // so whether we do it is a server wide choice
+        if (($CONFIG['AUTH_SESSION_BIND_IP'] ?? "Enabled") == "Enabled") $this->checkTokenIpAddress($tokenCheck);
+
+        $this->refreshTokenLastUsed($tokenCheck);
 
         //Tests have passed, return the token
         return $tokenCheck;
@@ -246,12 +278,13 @@ class bID
         if (is_null($userID)) throw new Exception("User ID cannot be null");
 
         if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) $ipAddress = $_SERVER["HTTP_CF_CONNECTING_IP"];
-        elseif(isset($_SERVER["HTTP_X_FORWARDED_FOR"])) $ipAddress = array_shift(explode(",", $_SERVER["HTTP_X_FORWARDED_FOR"]));
+        elseif(isset($_SERVER["HTTP_X_FORWARDED_FOR"])) $ipAddress = $this->clientIpFromForwardedFor($_SERVER["HTTP_X_FORWARDED_FOR"]);
         else $ipAddress = $_SERVER["REMOTE_ADDR"];
 
         $tokenKey = $this->generateTokenKey();
         $data = [
             "authTokens_created" => date('Y-m-d G:i:s'),
+            "authTokens_lastUsed" => date('Y-m-d H:i:s'), //Sliding expiry is measured from here
             "authTokens_token" => $tokenKey,
             "users_userid" => $userID,
             "authTokens_deviceType" => $deviceType,
@@ -287,7 +320,7 @@ class bID
             "iss" => $CONFIG['ROOTURL'],
             "uid" => $userID,
             "token" => $token,
-            "exp" => time()+12*60*60, //12 hours token expiry
+            "exp" => time() + $this->tokenLifetimeSeconds($type), //Matches the server wide session length
             "iat" => time(),
             "type" => $type
         ), $CONFIG['AUTH_JWTKey'], 'HS256');

--- a/src/common/libs/Config/configStructureArray.php
+++ b/src/common/libs/Config/configStructureArray.php
@@ -411,6 +411,51 @@ $configStructureArray = [
     "default" => "Disabled",
     "envFallback" => "CONFIG_CSP_ENABLED",
   ],
+  "AUTH_SESSION_LIFETIME_DAYS" => [
+    "form" => [
+      "type" => "number",
+      "default" => function () {
+        return 7;
+      },
+      "name" => "Login session length (days)",
+      "group" => "Security & Login",
+      "description" => "How long a login lasts before the user has to sign in again. The clock is reset by activity, so someone using the site is never signed out mid-task - only this many days of complete inactivity will end the session. Applies to the browser session and the mobile app. Emailed magic login links always expire after 12 hours regardless of this setting.",
+      "required" => true,
+      "maxlength" => 3,
+      "minlength" => 1,
+      "options" => [],
+      "verifyMatch" => function ($value, $options) {
+        if (!is_numeric($value)) return ["valid" => false, "value" => null, "error" => "Must be a whole number of days"];
+        $days = intval($value);
+        if ($days < 1 or $days > 365) return ["valid" => false, "value" => null, "error" => "Must be between 1 and 365 days"];
+        return ["valid" => true, "value" => (string) $days, "error" => null];
+      }
+    ],
+    "specialRequest" => false,
+    "default" => 7,
+    "envFallback" => "CONFIG_AUTH_SESSION_LIFETIME_DAYS",
+  ],
+  "AUTH_SESSION_BIND_IP" => [
+    "form" => [
+      "type" => "select",
+      "default" => function () {
+        return "Enabled";
+      },
+      "name" => "Lock sessions to IP address",
+      "group" => "Security & Login",
+      "description" => "Whether a login is tied to the IP address it was created from. Enabling this limits the damage a stolen session could do, but it signs users out the moment their IP changes - switching between Wi-Fi and mobile data, a VPN, or an ISP that reconnects with a new address. Disable this if users report being logged out at random.",
+      "required" => true,
+      "maxlength" => 255,
+      "minlength" => 5,
+      "options" => ["Enabled", "Disabled"],
+      "verifyMatch" => function ($value, $options) {
+        return ["valid" => in_array($value, $options), "value" => $value, "error" => in_array($value, $options) ? '' : "Invalid option selected"];
+      }
+    ],
+    "specialRequest" => false,
+    "default" => "Enabled",
+    "envFallback" => "CONFIG_AUTH_SESSION_BIND_IP",
+  ],
   "AUTH_PROVIDERS_GOOGLE_KEYS_ID" => [
     "form" => [
       "type" => "text",

--- a/src/server/config.twig
+++ b/src/server/config.twig
@@ -43,7 +43,7 @@
                                 </select>
                             {% else %}
                                 {% set secretFieldHasValue = field.form.type == 'secret' and null is not same as(field.value) and field.value is not same as(false) %}
-                                <input type="{{ field.form.type == 'secret' ? 'password' : field.form.type }}" class="form-control" name="{{ key|escape('html_attr') }}" value="{{ secretFieldHasValue ? '' : (null is same as(field.value) ? field.form.default|escape('html_attr') : field.value|escape('html_attr')) }}" placeholder="{{ secretFieldHasValue ? 'Leave blank to keep existing value' : field.form.default|escape('html_attr') }}" {{ field.form.required ? "required" : ''}} {{ field.form.minlength ? ('minlength="' ~ field.form.minlength ~ '"')|raw : '' }} {{ field.form.maxlength ? ('maxlength="' ~ field.form.maxlength ~ '"')|raw : '' }}/>
+                                <input type="{{ field.form.type == 'secret' ? 'password' : field.form.type }}" class="form-control" name="{{ key|escape('html_attr') }}" value="{{ secretFieldHasValue ? '' : (null is same as(field.value) ? field.form.default|escape('html_attr') : field.value|escape('html_attr')) }}" placeholder="{{ secretFieldHasValue ? 'Leave blank to keep existing value' : field.form.default|escape('html_attr') }}" {{ field.form.required and not secretFieldHasValue ? "required" : ''}} {{ field.form.minlength and not secretFieldHasValue ? ('minlength="' ~ field.form.minlength ~ '"')|raw : '' }} {{ field.form.maxlength ? ('maxlength="' ~ field.form.maxlength ~ '"')|raw : '' }}/>
                             {% endif %}
                         {% endfor %}
                         <br/><br/>


### PR DESCRIPTION
Closes #1017

## Problem
Users get logged out mid-task. Two things combine:

1. Auth tokens are hard-coded to expire **12 hours after creation**, measured from login and never refreshed.
2. The session cookie is set to 12 hours, but nothing raises `session.gc_maxlifetime`, so PHP's default **24 minutes idle** silently bins the session. Session files also live in `/tmp`, swept on a container restart.

Net effect: signed out after ~24 min idle, and again on every restart, with no admin control over the window.

## What this changes
Logins now expire on **inactivity**, over a **server-configurable** period, and survive restarts.

- **Sliding expiry.** A new `authTokens_lastUsed` column records the last time a token authenticated a request; expiry is measured from there, so active users are never cut off mid-task. The timestamp is only bumped when it has gone stale (older than 5 min) to keep writes down.
- **Configurable length.** New setting **Login session length (days)** (`AUTH_SESSION_LIFETIME_DAYS`, default 7, range 1–365) drives the token lifetime and the PHP session cookie / `gc_maxlifetime`. Emailed magic links keep their fixed 12-hour expiry.
- **Optional IP pinning.** New setting **Lock sessions to IP address** (`AUTH_SESSION_BIND_IP`), on by default, lets a server stop tying sessions to an IP (which otherwise logs people out on Wi-Fi ↔ mobile data, VPN, or ISP reconnect).
- **Survives restarts.** Session files move to a dedicated `/var/lib/adamrms-sessions` (created in the image, owned by `www-data`, overridable via `SESSION_SAVE_PATH`) instead of `/tmp`. Cookie hardened: `httponly`, `SameSite=Lax`, `secure` only on real https (respecting `X-Forwarded-Proto`), `use_strict_mode` on.

## Included prerequisite: the server config form couldn't be saved
Setting the values above means saving **Server → Config**, which currently cannot be submitted once a `required` secret field is set: the field renders blank ("leave blank to keep existing") but still carries `required` / `minlength`, so the browser blocks the form. `AUTH_JWTKey` (required, secret, always set with a generated default) triggers this on a stock instance. Secret fields that already hold a value no longer carry those attributes (`src/server/config.twig`). Bundled here because the new settings are otherwise unreachable.

## Files
- `db/migrations/20260901120000_auth_token_last_used.php` — adds `authTokens_lastUsed`, backfilled from `authTokens_created`.
- `src/common/libs/Auth/main.php` — sliding expiry, config-gated IP check, last-used refresh, JWT `exp` follows the configured length.
- `src/common/head.php` — cookie lifetime, `gc_maxlifetime`, dedicated save path, cookie hardening, https detection, per-request cookie re-send.
- `src/common/headSecure.php` — return-URL keeps the request scheme.
- `src/common/libs/Config/configStructureArray.php` — the two new settings.
- `src/server/config.twig` — the secret-field save fix.
- `Dockerfile` — creates the session directory.

## Notes / questions for the maintainer
- **The invasive one** — a migration, a Dockerfile change, and two new settings. Happy to split the `config.twig` fix into its own PR if you'd rather.
- Defaults keep current behaviour where sensible: IP pinning **on**; session length **7 days** (up from ~12h) — say if you'd prefer shorter.
- `SESSION_SAVE_PATH` should point at a persistent volume in existing deployments to get the restart-survival benefit — worth a line in the deploy docs.

## How to test
1. **Config form** — Server → Config saves with the JWT key already set (previously blocked); the two new settings appear under "Security & Login" and persist.
2. **Sliding session** — stay logged in past 24 min idle; activity keeps it alive; `authTokens_lastUsed` advances (≤ every 5 min).
3. **Session length** — lower it and confirm a session idle beyond it expires.
4. **IP pinning** — disabled, a session survives an IP change; enabled, it ends on IP change.
5. **Restart** — `docker restart` the app; an existing session stays logged in.
6. **Migration** — `phinx migrate` adds + backfills the column; `phinx rollback` reverses it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
